### PR TITLE
release: Run other workflows explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,15 @@ jobs:
           tag_name: ${{ steps.get_version.outputs.TAG_VERSION }}
           files: "*.tar.gz"
           body_path: gh-release.md
+
+      - name: Run docs workflow
+        run: |
+          gh workflow run docs.yml --ref main
+          gh workflow run docs.yml --ref ${{ steps.get_version.outputs.TAG_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run ci workflow
+        run: gh workflow run ci.yml --ref main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
 
       - name: Create release tag
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name kubevirt-bot
+          git config user.email kubevirtbot@redhat.com
           git tag -a ${{ steps.get_version.outputs.TAG_VERSION }} -m "Release v${{ steps.get_version.outputs.TAG_VERSION }}" || true
           git push origin --tags
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

To bypass restrictions on GitHub Actions run the docs and ci workflows manually after creating a release. GitHub Actions does not trigger other workflows from a workflow run if not using a personal access token (PAT). By calling the workflows explicitly, it is possible to work around this restriction without the need for a PAT.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
