### PR TITLE
ci: Exclude py3.9 with Ansible milestone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
               "python-version": "3.8"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.7"
             },
@@ -158,6 +162,10 @@ jobs:
             {
               "ansible-version": "milestone",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
             },
             {
               "ansible-version": "devel",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Python 3.9 is no longer supported by the latest Ansible milestone version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
