### PR TITLE
Drop old changelog fragments

### DIFF
--- a/changelogs/fragments/0_flatten_groups.yml
+++ b/changelogs/fragments/0_flatten_groups.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "inventory: Drop creation of the namespace_vmis_group as it is redundant"

--- a/changelogs/fragments/1_add_create_groups.yml
+++ b/changelogs/fragments/1_add_create_groups.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "inventory: Allow to control creation of additional groups"

--- a/changelogs/fragments/3_add_kubevirt_vm_info.yml
+++ b/changelogs/fragments/3_add_kubevirt_vm_info.yml
@@ -1,2 +1,0 @@
-major_changes:
-  - "Add kubevirt_vm_info module to describe existing VirtualMachines"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Drop old changelog fragments, they were consumed in the 1.1.0 release.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
