### PR TITLE
Add changelog to lint ignores

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,6 +7,7 @@ exclude_paths:
   - .yamllint
   - meta/
   - playbooks/roles/
+  - changelogs/changelog.yaml
 
 enable_list:
   - fqcn-builtins  # opt-in


### PR DESCRIPTION

**What this PR does / why we need it**:

antsibull-changelog generates yaml format which ansible-lint doesn't like

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
