### PR TITLE
ci: Add yamllint to CI linter job

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
+---
 # .ansible-lint
 exclude_paths:
   - .github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install yamllint ansible-core ansible-lint
 
-      - name: Run linter
+      - name: Run yamllint
+        run: |
+          yamllint .
+        working-directory: ${{ env.collection_dir }}
+
+      - name: Run ansible-lint
         run: |
           ansible-lint --version
           ansible-lint -v

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -92,7 +92,6 @@ jobs:
       - name: Install kubevirt.core collection
         id: install
         if: inputs.ansible_test_targets != ''
-        # yamllint disable-line rule:line-length
         uses: ansible-network/github_actions/.github/actions/build_install_collection@main
         with:
           install_python_dependencies: true
@@ -124,7 +123,6 @@ jobs:
 
       - name: Run integration tests
         if: inputs.ansible_test_targets != ''
-        # yamllint disable-line rule:line-length
         uses: ansible-network/github_actions/.github/actions/ansible_test_integration@main
         with:
           collection_path: ${{ steps.install.outputs.collection_path }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 140

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,3 +1,4 @@
+---
 ancestor: 1.0.0
 releases:
   1.0.0:

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,3 +1,4 @@
+---
 changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml

--- a/examples/inventory.kubevirt.yml
+++ b/examples/inventory.kubevirt.yml
@@ -1,3 +1,4 @@
+---
 plugin: kubevirt.core.kubevirt
 connections:
   - namespaces:

--- a/examples/kubesecondarydns.kubevirt.yml
+++ b/examples/kubesecondarydns.kubevirt.yml
@@ -1,3 +1,4 @@
+---
 plugin: kubevirt.core.kubevirt
 connections:
   - namespaces:

--- a/examples/play-create-dv.yml
+++ b/examples/play-create-dv.yml
@@ -1,3 +1,4 @@
+---
 - name: Playbook creating a virtual machine with data volume
   hosts: localhost
   tasks:

--- a/examples/play-create-min.yml
+++ b/examples/play-create-min.yml
@@ -1,3 +1,4 @@
+---
 - name: Playbook instantiating a virtual machine
   hosts: localhost
   tasks:

--- a/examples/play-create.yml
+++ b/examples/play-create.yml
@@ -1,3 +1,4 @@
+---
 - name: Playbook creating a virtual machine with multus network
   hosts: localhost
   tasks:

--- a/examples/play-delete-dv.yml
+++ b/examples/play-delete-dv.yml
@@ -1,3 +1,4 @@
+---
 - name: Playbook terminating a virtual machine with data volume
   hosts: localhost
   tasks:

--- a/examples/play-delete.yml
+++ b/examples/play-delete.yml
@@ -1,3 +1,4 @@
+---
 - name: Playbook terminating a virtual machine
   hosts: localhost
   tasks:

--- a/examples/play-info-list.yml
+++ b/examples/play-info-list.yml
@@ -1,3 +1,4 @@
+---
 - name: Playbook describing a virtual machine
   hosts: localhost
   tasks:

--- a/examples/play-info.yml
+++ b/examples/play-info.yml
@@ -1,3 +1,4 @@
+---
 - name: Playbook describing a virtual machine
   hosts: localhost
   tasks:

--- a/examples/services.kubevirt.yml
+++ b/examples/services.kubevirt.yml
@@ -1,3 +1,4 @@
+---
 plugin: kubevirt.core.kubevirt
 connections:
   - namespaces:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,3 +1,4 @@
+---
 namespace: kubevirt
 name: core
 version: "1.1.0"

--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -138,7 +138,7 @@ EXAMPLES = """
       api_key: xxxxxxxxxxxxxxxx
       validate_certs: false
 
-- name: Use default ~/.kube/config and return VirtualMachineInstances from namespace testing with interfaces connected to network bridge-network
+- name: Use default ~/.kube/config and return VirtualMachineInstances from namespace testing connected to network bridge-network
   plugin: kubevirt.core.kubevirt
   connections:
     - namespaces:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
+---
 collections:
   - name: kubernetes.core
     version: '>=2.0.0'

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,2 +1,3 @@
+---
 modules:
   python_requires: ">=3.11.0,<3.12.0"

--- a/tests/integration/targets/inventory_kubevirt/playbook.yml
+++ b/tests/integration/targets/inventory_kubevirt/playbook.yml
@@ -1,3 +1,4 @@
+---
 - name: Create VM
   connection: local
   gather_facts: false

--- a/tests/integration/targets/inventory_kubevirt/test.kubevirt.yml
+++ b/tests/integration/targets/inventory_kubevirt/test.kubevirt.yml
@@ -1,3 +1,4 @@
+---
 plugin: kubevirt.core.kubevirt
 connections:
   - namespaces:

--- a/tests/integration/targets/inventory_kubevirt/test.label.kubevirt.yml
+++ b/tests/integration/targets/inventory_kubevirt/test.label.kubevirt.yml
@@ -1,3 +1,4 @@
+---
 plugin: kubevirt.core.kubevirt
 connections:
   - namespaces:

--- a/tests/integration/targets/inventory_kubevirt/test.net.kubevirt.yml
+++ b/tests/integration/targets/inventory_kubevirt/test.net.kubevirt.yml
@@ -1,3 +1,4 @@
+---
 plugin: kubevirt.core.kubevirt
 connections:
   - namespaces:

--- a/tests/integration/targets/kubevirt_vm/test.kubevirt.yml
+++ b/tests/integration/targets/kubevirt_vm/test.kubevirt.yml
@@ -1,3 +1,4 @@
+---
 plugin: kubevirt.core.kubevirt
 connections:
   - namespaces:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds yamllint to the CI linter job and sets the maximum line
length to 140 like in kubevirt/kubevirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Based on #38, merge first

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
