### PR TITLE
chore: Bump dependency on kubernetes.core

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,3 +1,4 @@
+---
 ancestor: 1.0.0
 releases:
   1.0.0:
@@ -7,14 +8,14 @@ releases:
   1.1.0:
     changes:
       major_changes:
-      - Add kubevirt_vm_info module to describe existing VirtualMachines
+        - Add kubevirt_vm_info module to describe existing VirtualMachines
       minor_changes:
-      - 'inventory: Allow to control creation of additional groups'
-      - 'inventory: Drop creation of the namespace_vmis_group as it is redundant'
+        - 'inventory: Allow to control creation of additional groups'
+        - 'inventory: Drop creation of the namespace_vmis_group as it is redundant'
     fragments:
-    - 0_flatten_groups.yml
-    - 1_add_create_groups.yml
-    - 3_add_kubevirt_vm_info.yml
+      - 0_flatten_groups.yml
+      - 1_add_create_groups.yml
+      - 3_add_kubevirt_vm_info.yml
     release_date: '2023-09-21'
   1.2.0:
     release_date: '2024-03-04'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ readme: README.md
 authors:
   - KubeVirt Project (kubevirt.io)
 dependencies:
-  kubernetes.core: '>=2.0.0'
+  kubernetes.core: '>=3.0.1'
 description: Lean Ansible bindings for KubeVirt
 license_file: LICENSE
 tags:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: kubernetes.core
-    version: '>=2.0.0'
+    version: '>=3.0.1'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Bump the dependency on kubernetes.core to versions >=3.0.1 and remove the workaround introduced by 4429ac8c038afc55316b50c165429cc91b4f9f52.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Depend on kubernetes.core version >=3.0.1
```
