### PR TITLE
tests: Cleanup after inventory test

### DIFF
--- a/tests/integration/targets/inventory_kubevirt/cleanup.yml
+++ b/tests/integration/targets/inventory_kubevirt/cleanup.yml
@@ -1,0 +1,19 @@
+---
+- name: Create VMs
+  connection: local
+  gather_facts: false
+  hosts: localhost
+  tasks:
+    - name: Create a VM
+      kubevirt.core.kubevirt_vm:
+        state: absent
+        name: testvm1
+        namespace: default
+        wait: true
+
+    - name: Create another VM
+      kubevirt.core.kubevirt_vm:
+        state: absent
+        name: testvm2
+        namespace: default
+        wait: true

--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -13,4 +13,6 @@ ansible-inventory -i test.kubevirt.yml -y --list --output all.yml "$@"
 ansible-inventory -i test.label.kubevirt.yml -y --list --output label.yml "$@"
 ansible-inventory -i test.net.kubevirt.yml -y --list --output net.yml "$@"
 
+ansible-playbook cleanup.yml "$@"
+
 ansible-playbook verify.yml "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Cleanup the created the created VMs after the inventory integration tests collected the inventory test results to not leave running VMs behind after the test finished.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
