### PR TITLE
galaxy.yml: Add .gitignores to build_ignore

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,3 +41,5 @@ build_ignore:
   - docs/conf.py
   - docs/roles.rst.template
   - docs/requirements.txt
+  - tests/integration/targets/inventory_kubevirt/.gitignore
+  - tests/integration/targets/kubevirt_vm/.gitignore


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add .gitignore files to build_ignore since we do not need them in the released collection.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
