### PR TITLE
fix: Explicity set ansible_port

### DIFF
--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -639,6 +639,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         Secondary interfaces have priority over a service exposing SSH
         """
         ansible_host = None
+        ansible_port = None
         if opts.kube_secondary_dns and opts.network_name is not None:
             # Set ansible_host to the kubesecondarydns derived host name if enabled
             # See https://github.com/kubevirt/kubesecondarydns#parameters
@@ -654,10 +655,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             port = self.get_port_from_service(service)
             if host is not None and port is not None:
                 ansible_host = host
-                self.inventory.set_variable(vmi_name, "ansible_port", port)
+                ansible_port = port
 
         # Default to the IP address of the interface if ansible_host was not set prior
         if ansible_host is None:
             ansible_host = ip_address
 
         self.inventory.set_variable(vmi_name, "ansible_host", ansible_host)
+        self.inventory.set_variable(vmi_name, "ansible_port", ansible_port)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Explicitly set ansible_port so it is reset in AWX inventories if the value changes from set to unset.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Explicitly set ansible_port so it is reset in AWX inventories if the value changes from set to unset.
```
