### PR TITLE
fix: Return early to avoid adding empty groups.

### DIFF
--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -448,6 +448,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 f"Error fetching VirtualMachineInstance list: {self.format_dynamic_api_exc(exc)}"
             ) from exc
 
+        if not vmi_list.items:
+            # Return early if no VMIs were found to avoid adding empty groups.
+            return
+
         services = self.get_ssh_services_for_namespace(client, namespace)
 
         name = self._sanitize_group_name(name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If no VMIs were found in a namespace then return early to avoid adding empty groups in the inventory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
inventory: Empty namespaces are no longer added as groups.
```
