### PR TITLE
feat: Give secondary interfaces a higher priority over services

### DIFF
--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -110,6 +110,7 @@ options:
       use_service:
         description:
         - Enable the use of services to establish an SSH connection to the VirtualMachine.
+        - Services are only used if no network_name was provided.
         type: bool
         default: True
       create_groups:
@@ -665,10 +666,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             )
             if opts.base_domain is not None:
                 ansible_host += f".{opts.base_domain}"
-        elif opts.use_service and service is not None:
+        elif opts.use_service and service is not None and opts.network_name is None:
             # Set ansible_host and ansible_port to the host and port from the LoadBalancer
             # or NodePort service exposing SSH
-            node_name = f"{vmi.status.nodeName}.{opts.base_domain}" if opts.append_base_domain else vmi.status.nodeName
+            node_name = (
+                f"{vmi.status.nodeName}.{opts.base_domain}"
+                if opts.append_base_domain
+                else vmi.status.nodeName
+            )
             host = self.get_host_from_service(service, node_name)
             port = self.get_port_from_service(service)
             if host is not None and port is not None:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

To give secondary interfaces a higher priority over services the use of services is disabled if a network_name was provided.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Give secondary interfaces a higher priority over services
```
