### PR TITLE
fix: add composite vars to inventory

### DIFF
--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -604,6 +604,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self.inventory.set_variable(
                 vmi_name, "vmi_volume_status", vmi_volume_status
             )
+            self.set_composable_vars(vmi_name)
+
+    def set_composable_vars(self, vmi_name):
+        """
+        set_composable_vars sets vars per
+        https://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html
+        """
+        host_vars = self.inventory.get_host(vmi_name).get_vars()
+        strict = self.get_option("strict")
+        self._set_composite_vars(self.get_option("compose"), host_vars, vmi_name, strict=True)
+        self._add_host_to_composed_groups(self.get_option("groups"), host_vars, vmi_name, strict=strict)
+        self._add_host_to_keyed_groups(self.get_option("keyed_groups"), host_vars, vmi_name, strict=strict)
 
     def get_ssh_services_for_namespace(self, client: K8SClient, namespace: str) -> Dict:
         """


### PR DESCRIPTION
Re-try from #69 
Docs seem to indicate compose variables should work, but they aren't actually set. Fix that by adding the composite variables to the inventory.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

inventory: Fix adding composite vars to the inventory.

```
