### PR TITLE
Add helper to build virtualenv and vscode configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,9 @@ bin/
 *.tar.gz
 *.zip
 
-# pytest-ansible
+# pytest-ansible and tox-ansible
 collections/
+kubevirt.core
 
 # Collection specific ignores
 /changelogs/.plugin-cache.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,12 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-.vscode/
+# Allow specific vscode configuration
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+
+# Local files
 .idea/
 bin/
 *.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ bin/
 *.tar.gz
 *.zip
 
+# pytest-ansible
+collections/
+
 # Collection specific ignores
 /changelogs/.plugin-cache.yaml
 /tests/output/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-python.debugpy",
+        "ms-python.vscode-pylance",
+        "github.vscode-github-actions"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,15 @@ build-venv:
 .PHONY: format
 format:
 	tox run -e format
+
+.PHONY: test-sanity
+test-sanity:
+	tox -f sanity --ansible -p auto --conf tox-ansible.ini
+
+.PHONY: test-unit
+test-unit:
+	tox -f unit --ansible -p auto --conf tox-ansible.ini
+
+.PHONY: test-integration
+test-integration:
+	tox -f integration --ansible --conf tox-ansible.ini

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,12 @@ cluster-up:
 .PHONY: cluster-down
 cluster-down:
 	hack/e2e-setup.sh --cleanup
+
+.PHONY: build-venv
+build-venv:
+	tox run -e venv
+	ln -sf .tox/venv .venv
+
+.PHONY: format
+format:
+	tox run -e format

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -35,6 +35,7 @@ build_ignore:
   - Makefile
   - OWNERS
   - REVIEW_CHECKLIST.md
+  - tox.ini
   - '*.tar.gz'
   - '*.zip'
   - docs/_gh_include

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -26,6 +26,7 @@ build_ignore:
   - .git
   - .gitignore
   - .github
+  - .vscode
   - .yamllint
   - bin
   - changelogs

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,4 @@
-kubernetes-validate
-coverage==4.5.4
-mock
 pytest
-pytest-xdist
-pytest-mock
-pytest-forked
-virtualenv
 pytest-ansible
+pytest-xdist
+tox-ansible

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+# No additional requirements at this moment
+# Have a look at /requirements.txt and /test-requirements.txt

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,0 @@
-jinja2
-jsonpatch
-kubernetes>=28.1.0
-PyYAML>=3.11
-pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+env_list = venv
+
+[testenv:venv]
+download = True
+deps =
+    -r requirements.txt
+    -r test-requirements.txt
+    -r tests/requirements.txt
+allowlist_externals =
+    mkdir
+    ln
+commands =
+    mkdir -p "{env_site_packages_dir}/ansible_collections/kubevirt"
+    ln -sf "{tox_root}" "{env_site_packages_dir}/ansible_collections/kubevirt/core"
+    ansible-galaxy collection install -r requirements.yml -p "{env_site_packages_dir}/ansible_collections" --force
+
+[testenv:format]
+deps =
+    black
+commands = black .
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- Add tox configuration that allows to build a venv for development and to
  format source files. To make use of it add appropriate Makefile targets.
- Drop unneeded requirements from requirements.txt and
  test-requirements.txt and add needed requirements.
- Add tox-ansible configuration that allows to run tests with all
  required ansible and python versions. Add Makefile targets to make use
  of it.
- Add vscode configuration that allows to develop, test and debug the
  collection.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
