### PR TITLE
fix(kubevirt_vm): Set wait_condition based on running

### DIFF
--- a/plugins/modules/kubevirt_vm.py
+++ b/plugins/modules/kubevirt_vm.py
@@ -380,7 +380,14 @@ def main() -> None:
     module.params["resource_definition"] = render_template(module.params)
 
     # Set wait_condition to allow waiting for the ready state of the VirtualMachine
-    module.params["wait_condition"] = {"type": "Ready", "status": True}
+    if module.params["running"]:
+        module.params["wait_condition"] = {"type": "Ready", "status": True}
+    else:
+        module.params["wait_condition"] = {
+            "type": "Ready",
+            "status": False,
+            "reason": "VMINotExists",
+        }
 
     try:
         runner.run_module(module)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

To properly wait for a state change the wait_condition needs to
adapted to the state of running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Wait for #88 to go in first

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adapt the wait_condition to properly wait for state changes.
```
