### PR TITLE
feat(kubevirt_vm_info): Set wait_condition based on running

### DIFF
--- a/tests/unit/plugins/modules/test_kubevirt_vm.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vm.py
@@ -268,7 +268,7 @@ def test_module_fails_when_required_args_missing(monkeypatch):
             "module_params_delete",
             "k8s_module_params_delete",
             "vm_definition_running",
-            "delete"
+            "delete",
         ),
     ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add the running parameter to kubevirt_vm_info from which the wait_condition is derived from when parameter wait is set to yes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the running parameter to kubevirt_vm_info that controls which ready condition to wait for.
```
