### PR TITLE
tests: add render_template unit tests

### DIFF
--- a/tests/unit/plugins/modules/test_kubevirt_vm.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vm.py
@@ -275,3 +275,347 @@ def test_module(
         request.getfixturevalue(vm_definition),
         request.getfixturevalue(k8s_module_params),
     )
+
+
+@pytest.fixture(scope="module")
+def render_template_params():
+    return {
+        "api_version": "kubevirt.io/v1",
+        "running": True,
+        "namespace": "default",
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_annotations(render_template_params):
+    return render_template_params | {
+        "annotations": {"test": "test"},
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_labels(render_template_params):
+    return render_template_params | {
+        "labels": {"test": "test"},
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_instancetype(render_template_params):
+    return render_template_params | {
+        "instancetype": {"name": "u1.medium"},
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_preference(render_template_params):
+    return render_template_params | {
+        "preference": {"name": "fedora"},
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_datavolumetemplate(render_template_params):
+    return render_template_params | {
+        "data_volume_templates": [
+            {
+                "metadata": {"name": "testdv"},
+                "spec": {
+                    "source": {
+                        "registry": {
+                            "url": "docker://quay.io/containerdisks/fedora:latest"
+                        },
+                    },
+                    "storage": {
+                        "accessModes": ["ReadWriteOnce"],
+                        "resources": {"requests": {"storage": "5Gi"}},
+                    },
+                },
+            },
+        ],
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_name(render_template_params):
+    return render_template_params | {
+        "name": "testvm",
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_generate_name(render_template_params):
+    return render_template_params | {
+        "generate_name": "testvm-1234",
+    }
+
+
+@pytest.fixture(scope="module")
+def render_template_params_specs(render_template_params):
+    return render_template_params | {
+        "spec": {
+            "domain": {
+                "devices": {
+                    "cpu": {
+                        "cores": 2,
+                        "socket": 1,
+                        "threads": 2,
+                    }
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "namespace": "default",
+        },
+        "spec": {
+            "running": True,
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_labels():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "namespace": "default",
+            "labels": {
+                "test": "test",
+            }
+        },
+        "spec": {
+            "running": True,
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "test": "test"
+                    },
+                },
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_annotations():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "namespace": "default",
+            "annotations": {
+                "test": "test",
+            }
+        },
+        "spec": {
+            "running": True,
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        "test": "test"
+                    },
+                },
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_instancetype():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "namespace": "default",
+        },
+        "spec": {
+            "running": True,
+            "instancetype": {
+                "name": "u1.medium"
+            },
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_preference():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "namespace": "default",
+        },
+        "spec": {
+            "running": True,
+            "preference": {
+                "name": "fedora"
+            },
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_datavolumetemplate():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "namespace": "default",
+        },
+        "spec": {
+            "running": True,
+            "dataVolumeTemplates": [
+                {
+                    "metadata": {"name": "testdv"},
+                    "spec": {
+                        "source": {
+                            "registry": {
+                                "url": "docker://quay.io/containerdisks/fedora:latest"
+                            },
+                        },
+                        "storage": {
+                            "accessModes": ["ReadWriteOnce"],
+                            "resources": {"requests": {"storage": "5Gi"}},
+                        },
+                    },
+                },
+            ],
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_name():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "name": "testvm",
+            "namespace": "default",
+        },
+        "spec": {
+            "running": True,
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_generate_name():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "generateName": "testvm-1234",
+            "namespace": "default",
+        },
+        "spec": {
+            "running": True,
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def vm_template_specs():
+    return {
+        "apiVersion": "kubevirt.io/v1",
+        "kind": "VirtualMachine",
+        "metadata": {
+            "namespace": "default",
+        },
+        "spec": {
+            "running": True,
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {
+                            "cpu": {
+                                "cores": 2,
+                                "socket": 1,
+                                "threads": 2,
+                            }
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "params,rendered_template",
+    [
+        ("render_template_params", "vm_template"),
+        ("render_template_params_annotations", "vm_template_annotations"),
+        ("render_template_params_labels", "vm_template_labels"),
+        ("render_template_params_instancetype", "vm_template_instancetype"),
+        ("render_template_params_preference", "vm_template_preference"),
+        ("render_template_params_datavolumetemplate", "vm_template_datavolumetemplate"),
+        ("render_template_params_name", "vm_template_name"),
+        ("render_template_params_generate_name", "vm_template_generate_name"),
+        ("render_template_params_specs", "vm_template_specs")
+    ],
+)
+def test_render_template(request, params, rendered_template):
+    result = kubevirt_vm.render_template(request.getfixturevalue(params))
+    assert result == dump(request.getfixturevalue(rendered_template), sort_keys=False)


### PR DESCRIPTION
**What this PR does / why we need it**:

- It adds unit tests for the render_template function. These test cases cover all cases for non-mandatory fields in the VM template.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-35424](https://issues.redhat.com/browse/CNV-35424)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
