### PR TITLE
fix: Ensure compatibility with kubernetes.core >=3.10,<4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ansible-galaxy collection install kubevirt-kubevirt.core-*.tar.gz
 <!--start collection_dependencies -->
 #### Ansible collections
 
-* [kubernetes.core](https://galaxy.ansible.com/ui/repo/published/kubernetes/core)>=3.0.1
+* [kubernetes.core](https://galaxy.ansible.com/ui/repo/published/kubernetes/core)>=3.1.0,<4.1.0
 
 To install all the dependencies:
 ```bash

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ readme: README.md
 authors:
   - KubeVirt Project (kubevirt.io)
 dependencies:
-  kubernetes.core: '>=3.0.1'
+  kubernetes.core: '>=3.1.0,<4.1.0'
 description: Lean Ansible bindings for KubeVirt
 license_file: LICENSE
 tags:

--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -182,21 +182,22 @@ from typing import (
 
 
 # Handle import errors of python kubernetes client.
-# HAS_K8S_MODULE_HELPER imported below will print a warning to the user if the client is missing.
+# Set HAS_K8S_MODULE_HELPER and k8s_import exception accordingly to
+# potentially print a warning to the user if the client is missing.
 try:
     from kubernetes.dynamic.exceptions import DynamicApiError
-except ImportError:
+
+    HAS_K8S_MODULE_HELPER = True
+    k8s_import_exception = None
+except ImportError as e:
 
     class DynamicApiError(Exception):
         pass
 
+    HAS_K8S_MODULE_HELPER = False
+    k8s_import_exception = e
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
-
-from ansible_collections.kubernetes.core.plugins.module_utils.common import (
-    HAS_K8S_MODULE_HELPER,
-    k8s_import_exception,
-)
 
 
 from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import (

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: kubernetes.core
-    version: '>=3.0.1'
+    version: '>=3.1.0,<4.1.0'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Ensure compatibility with kubernetes.core >=3.10,<4.1.0 by replacing deprecated imports of HAS_K8S_MODULE_HELPER and k8s_import_exception.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #30
Fixes #31 
Fixes #99

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure compatibility with kubernetes.core >=3.10,<4.1.0
```
