### PR TITLE
Make kubevirt_vm tests more robust

### DIFF
--- a/tests/integration/targets/kubevirt_vm/runme.sh
+++ b/tests/integration/targets/kubevirt_vm/runme.sh
@@ -13,4 +13,18 @@ ansible-playbook playbook.yml "$@"
 
 ansible-inventory -i test.kubevirt.yml -y --list "$@"
 
-ansible-playbook verify.yml -i test.kubevirt.yml --private-key=files/testkey "$@"
+# Retry connection to VM until a login is possible
+# This is necessary since wait_for is not enough to wait for logins to be possible.
+# wait_for is only able to wait until sshd accepts connections.
+retries=0
+while ! ansible-playbook wait_for_vm.yml -i test.kubevirt.yml --private-key=files/testkey "$@"; do
+  if [ "$retries" -ge "10" ]; then
+    echo "Maximum retries reached, giving up"
+    exit 1
+  fi
+  echo "Failed to wait for VM, retrying..."
+  sleep 10
+  ((retries+=1))
+done
+
+ansible-playbook verify.yml --diff -i test.kubevirt.yml --private-key=files/testkey "$@"

--- a/tests/integration/targets/kubevirt_vm/verify.yml
+++ b/tests/integration/targets/kubevirt_vm/verify.yml
@@ -11,10 +11,15 @@
         labels:
           app: test
       register: recreate
-    - name: Assert module reported no changes
+    - name: Assert module reported no or expected changes
       ansible.builtin.assert:
         that:
-          - not recreate.changed
+          - >-
+            not recreate.changed or
+            recreated.changed and
+            recreated.method == "update" and
+            recreated.diff.before.metadata.annotations.get('kubemacpool.io/transaction-timestamp') and
+            not recreated.diff.after.metadata.annotations
 
 - name: Delete VM
   connection: local

--- a/tests/integration/targets/kubevirt_vm/verify.yml
+++ b/tests/integration/targets/kubevirt_vm/verify.yml
@@ -1,27 +1,4 @@
 ---
-- name: Wait for SSH
-  connection: local
-  gather_facts: false
-  hosts: localhost
-  tasks:
-    - name: Wait up to 900 seconds for port 22 to become open
-      ansible.builtin.wait_for:
-        port: 22
-        host: "{{ hostvars['default-testvm'].ansible_host }}"
-        delay: 30
-        timeout: 900
-
-- name: Connect to VM
-  gather_facts: true
-  hosts: default-testvm
-  remote_user: cloud-user
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
-  tasks:
-    - name: Print VM facts
-      ansible.builtin.debug:
-        var: ansible_facts
-
 - name: Verify creation with existing VM
   connection: local
   gather_facts: false

--- a/tests/integration/targets/kubevirt_vm/wait_for_vm.yml
+++ b/tests/integration/targets/kubevirt_vm/wait_for_vm.yml
@@ -1,0 +1,24 @@
+---
+- name: Wait for SSH
+  connection: local
+  gather_facts: false
+  hosts: localhost
+  tasks:
+    - name: Wait up to 900 seconds for port 22 to become open
+      ansible.builtin.wait_for:
+        port: 22
+        host: "{{ hostvars['default-testvm'].ansible_host }}"
+        search_regex: OpenSSH
+        delay: 10
+        timeout: 900
+
+- name: Connect to VM
+  gather_facts: true
+  hosts: default-testvm
+  remote_user: cloud-user
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - name: Print VM facts
+      ansible.builtin.debug:
+        var: ansible_facts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- This changes the runme.sh of the kubevirt_vm integration tests to retry
the connection to the VM until a login is possible. This is necessary
since it is not possible with Ansible alone to retry a task in case the
connection failed with the unreachable status. This can happen when the
sshd of the VM already accepts connections but a login is not yet
possible because the VM is still booting up.

- Assert there are no or expected changes in verify.yml of the kubevirt_vm
integration test. This is necessary since in downstream tests the
kubemacpool operator might add annotations to the VM which can trigger a
changed result.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #98 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
