### PR TITLE
fix(ci): Do not test ansible-core devel with py3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
           {
             "ansible-version": "devel",
             "python-version": "3.9"
+          },
+          {
+            "ansible-version": "devel",
+            "python-version": "3.10"
           }
         ]
 
@@ -111,6 +115,10 @@ jobs:
           {
             "ansible-version": "devel",
             "python-version": "3.9"
+          },
+          {
+            "ansible-version": "devel",
+            "python-version": "3.10"
           }
         ]
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,10 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.9"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.10"
             }
           ]
         required: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Python 3.10 is no longer supported by ansible-core devel, so this excludes it from the test matrices.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
