### PR TITLE
fix(inventory): Fix inventory source caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,7 +145,10 @@ kubevirt.core
 /tests/output/
 /tests/integration/inventory
 /tests/integration/targets/inventory_kubevirt/all.yml
+/tests/integration/targets/inventory_kubevirt/cache_after.yml
+/tests/integration/targets/inventory_kubevirt/cache_before.yml
 /tests/integration/targets/inventory_kubevirt/empty.yml
 /tests/integration/targets/inventory_kubevirt/label.yml
 /tests/integration/targets/inventory_kubevirt/net.yml
 /tests/integration/targets/kubevirt_vm/files
+kubevirt-cache

--- a/examples/cache.kubevirt.yml
+++ b/examples/cache.kubevirt.yml
@@ -1,0 +1,5 @@
+---
+plugin: kubevirt.core.kubevirt
+cache: true
+cache_plugin: ansible.builtin.jsonfile
+cache_connection: kubevirt-cache

--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -423,13 +423,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def connections_compatibility(self, config_data: Dict) -> None:
         collection_name = "kubevirt.core"
+        version_removed_in = "3.0.0"
 
         if (connections := config_data.get("connections")) is None:
             return
 
         self.display.deprecated(
             msg="The 'connections' parameter is deprecated and now supports only a single list entry.",
-            version="2.0.0",
+            version=version_removed_in,
             collection_name=collection_name,
         )
 
@@ -446,7 +447,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 config_data[k] = v
             self.display.deprecated(
                 msg="Move all of your connection parameters to the configuration top level.",
-                version="3.0.0",
+                version=version_removed_in,
                 collection_name=collection_name,
             )
         elif len(connections) > 1:

--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -251,7 +251,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     snake_case_pattern = re_compile(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
     @staticmethod
-    def get_default_host_name(host: str) -> str:
+    def get_default_hostname(host: str) -> str:
         """
         get_default_host_name strips URL schemes from the host name and
         replaces invalid characters.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-addict
 pytest
 pytest-ansible
 pytest-mock

--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -10,9 +10,12 @@ ansible-inventory -i test.kubevirt.yml -y --list --output empty.yml "$@"
 ansible-playbook playbook.yml "$@"
 
 ansible-inventory -i test.kubevirt.yml -y --list --output all.yml "$@"
+ansible-inventory -i test.cache.kubevirt.yml -y --list --output cache_before.yml "$@"
 ansible-inventory -i test.label.kubevirt.yml -y --list --output label.yml "$@"
 ansible-inventory -i test.net.kubevirt.yml -y --list --output net.yml "$@"
 
 ansible-playbook cleanup.yml "$@"
+
+ansible-inventory -i test.cache.kubevirt.yml -y --list --output cache_after.yml "$@"
 
 ansible-playbook verify.yml "$@"

--- a/tests/integration/targets/inventory_kubevirt/test.cache.kubevirt.yml
+++ b/tests/integration/targets/inventory_kubevirt/test.cache.kubevirt.yml
@@ -1,0 +1,9 @@
+---
+plugin: kubevirt.core.kubevirt
+name: test
+namespaces:
+  - default
+create_groups: true
+cache: true
+cache_plugin: ansible.builtin.jsonfile
+cache_connection: kubevirt-cache

--- a/tests/integration/targets/inventory_kubevirt/verify.yml
+++ b/tests/integration/targets/inventory_kubevirt/verify.yml
@@ -38,3 +38,16 @@
       ansible.builtin.assert:
         that:
           - inv_net['all']['children']['label_app_test']['hosts'] | length == 1
+    - name: Read cached inventory after VM creation
+      ansible.builtin.include_vars:
+        file: cache_before.yml
+        name: inv_cache_before
+    - name: Read cached inventory after VM deletion
+      ansible.builtin.include_vars:
+        file: cache_after.yml
+        name: inv_cache_after
+    - name: Assert cached inventories are populated
+      ansible.builtin.assert:
+        that:
+          - inv_cache_before == inv_all
+          - inv_cache_before == inv_cache_after

--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_ansible_connection_winrm.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_ansible_connection_winrm.py
@@ -8,7 +8,6 @@ __metaclass__ = type
 
 import pytest
 
-
 from ansible_collections.kubevirt.core.plugins.inventory.kubevirt import (
     InventoryOptions,
 )
@@ -60,19 +59,25 @@ WINDOWS_VMI_4 = merge_dicts(
 
 
 @pytest.mark.parametrize(
-    "client,vmi,expected",
+    "vmi,expected",
     [
-        ({"vmis": [BASE_VMI]}, BASE_VMI, False),
-        ({"vmis": [WINDOWS_VMI_1]}, WINDOWS_VMI_1, True),
-        ({"vmis": [WINDOWS_VMI_2]}, WINDOWS_VMI_2, True),
-        ({"vmis": [WINDOWS_VMI_3]}, WINDOWS_VMI_3, True),
-        ({"vmis": [WINDOWS_VMI_4]}, WINDOWS_VMI_4, True),
+        (BASE_VMI, False),
+        (WINDOWS_VMI_1, True),
+        (WINDOWS_VMI_2, True),
+        (WINDOWS_VMI_3, True),
+        (WINDOWS_VMI_4, True),
     ],
-    indirect=["client"],
 )
-def test_ansible_connection_winrm(inventory, hosts, client, vmi, expected):
-    inventory.populate_inventory_from_namespace(
-        client, "", DEFAULT_NAMESPACE, InventoryOptions()
+def test_ansible_connection_winrm(inventory, hosts, vmi, expected):
+    inventory.populate_inventory(
+        {
+            "default_hostname": "test",
+            "cluster_domain": "test.com",
+            "namespaces": {
+                "default": {"vms": [], "vmis": [vmi], "services": {}},
+            },
+        },
+        InventoryOptions(),
     )
 
     host = f"{DEFAULT_NAMESPACE}-{vmi['metadata']['name']}"

--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_ansible_connection_winrm.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_ansible_connection_winrm.py
@@ -22,7 +22,9 @@ BASE_VMI = {
     "metadata": {
         "name": "testvmi",
         "namespace": "default",
+        "uid": "e86c603c-fb13-4933-bf67-de100bdba0c3",
     },
+    "spec": {},
     "status": {
         "interfaces": [{"ipAddress": "10.10.10.10"}],
     },

--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_set_composable_vars.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_set_composable_vars.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import pytest
-
 from ansible_collections.kubevirt.core.plugins.inventory.kubevirt import (
     InventoryOptions,
 )
@@ -36,16 +34,10 @@ VMI = {
 }
 
 
-@pytest.mark.parametrize(
-    "client",
-    [{"vmis": [VMI]}],
-    indirect=["client"],
-)
 def test_set_composable_vars(
     inventory,
     groups,
     hosts,
-    client,
 ):
     inventory._options = {
         "compose": {"set_from_another_var": "vmi_node_name"},
@@ -53,8 +45,15 @@ def test_set_composable_vars(
         "keyed_groups": [{"prefix": "fedora", "key": "vmi_guest_os_info.versionId"}],
         "strict": True,
     }
-    inventory.populate_inventory_from_namespace(
-        client, "", DEFAULT_NAMESPACE, InventoryOptions()
+    inventory.populate_inventory(
+        {
+            "default_hostname": "test",
+            "cluster_domain": "test.com",
+            "namespaces": {
+                "default": {"vms": [], "vmis": [VMI], "services": {}},
+            },
+        },
+        InventoryOptions(),
     )
 
     host = f"{DEFAULT_NAMESPACE}-testvmi"

--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_set_composable_vars.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_set_composable_vars.py
@@ -21,7 +21,9 @@ VMI = {
     "metadata": {
         "name": "testvmi",
         "namespace": "default",
+        "uid": "6ffdef43-6c39-4441-a088-82d319ea5c13",
     },
+    "spec": {},
     "status": {
         "interfaces": [{"ipAddress": "10.10.10.10"}],
         "migrationMethod": "BlockMigration",

--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_stopped_vm.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_stopped_vm.py
@@ -6,15 +6,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import pytest
-
-
 from ansible_collections.kubevirt.core.plugins.inventory.kubevirt import (
     InventoryOptions,
-)
-
-from ansible_collections.kubevirt.core.tests.unit.plugins.inventory.constants import (
-    DEFAULT_NAMESPACE,
 )
 
 VM1 = {
@@ -50,16 +43,16 @@ VMI1 = {
 }
 
 
-@pytest.mark.parametrize(
-    "client",
-    [
-        ({"vms": [VM1, VM2], "vmis": [VMI1]}),
-    ],
-    indirect=["client"],
-)
-def test_stopped_vm(inventory, hosts, client):
-    inventory.populate_inventory_from_namespace(
-        client, "", DEFAULT_NAMESPACE, InventoryOptions()
+def test_stopped_vm(inventory, hosts):
+    inventory.populate_inventory(
+        {
+            "default_hostname": "test",
+            "cluster_domain": "test.com",
+            "namespaces": {
+                "default": {"vms": [VM1, VM2], "vmis": [VMI1], "services": {}},
+            },
+        },
+        InventoryOptions(),
     )
 
     # The running VM should be present with ansible_host or ansible_port

--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_stopped_vm.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_stopped_vm.py
@@ -24,6 +24,7 @@ VM1 = {
         "uid": "940003aa-0160-4b7e-9e55-8ec3df72047f",
     },
     "spec": {"running": True},
+    "status": {},
 }
 
 VM2 = {
@@ -33,6 +34,7 @@ VM2 = {
         "uid": "c2c68de5-b9d7-4c25-872f-462e7245b3e6",
     },
     "spec": {"running": False},
+    "status": {},
 }
 
 VMI1 = {
@@ -41,6 +43,7 @@ VMI1 = {
         "namespace": "default",
         "uid": "a84319a9-db31-4a36-9b66-3e387578f871",
     },
+    "spec": {},
     "status": {
         "interfaces": [{"ipAddress": "10.10.10.10"}],
     },

--- a/tests/unit/plugins/inventory/conftest.py
+++ b/tests/unit/plugins/inventory/conftest.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import pytest
 
-from addict import Dict
+from kubernetes.dynamic.resource import ResourceField
 
 from ansible.template import Templar
 
@@ -96,21 +96,21 @@ def client(mocker, request):
         items = param["namespaces"]
     else:
         items = [{"metadata": {"name": DEFAULT_NAMESPACE}}]
-    namespaces.items = [Dict(item) for item in items]
+    namespaces.items = [ResourceField(item) for item in items]
 
     vms = mocker.Mock()
-    vms.items = [Dict(item) for item in param.get("vms", [])]
+    vms.items = [ResourceField(item) for item in param.get("vms", [])]
     vmis = mocker.Mock()
-    vmis.items = [Dict(item) for item in param.get("vmis", [])]
+    vmis.items = [ResourceField(item) for item in param.get("vmis", [])]
     services = mocker.Mock()
-    services.items = [Dict(item) for item in param.get("services", [])]
+    services.items = [ResourceField(item) for item in param.get("services", [])]
 
     dns = mocker.Mock()
     if "base_domain" in param:
         base_domain = param["base_domain"]
     else:
         base_domain = DEFAULT_BASE_DOMAIN
-    dns_obj = Dict({"spec": {"baseDomain": base_domain}})
+    dns_obj = ResourceField({"spec": {"baseDomain": base_domain}})
     dns.items = [dns_obj]
 
     namespace_client = mocker.Mock()

--- a/tests/unit/plugins/inventory/test_kubevirt.py
+++ b/tests/unit/plugins/inventory/test_kubevirt.py
@@ -27,8 +27,8 @@ from ansible_collections.kubevirt.core.tests.unit.plugins.inventory.constants im
         ("https://example.com:8080", "example-com_8080"),
     ],
 )
-def test_get_default_host_name(host, expected):
-    assert InventoryModule.get_default_host_name(host) == expected
+def test_get_default_hostname(host, expected):
+    assert InventoryModule.get_default_hostname(host) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/plugins/inventory/test_kubevirt_add_host.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_add_host.py
@@ -8,8 +8,6 @@ __metaclass__ = type
 
 import pytest
 
-from addict import Dict
-
 from ansible_collections.kubevirt.core.tests.unit.plugins.inventory.constants import (
     DEFAULT_NAMESPACE,
 )
@@ -65,15 +63,11 @@ def test_add_host(inventory, groups, hosts, host_format, expected):
     inventory.inventory.add_group(namespace_group)
 
     inventory.add_host(
-        Dict(
-            {
-                "metadata": {
-                    "name": "testvm",
-                    "namespace": DEFAULT_NAMESPACE,
-                    "uid": "f8abae7c-d792-4b9b-af95-62d322ae5bc1",
-                }
-            }
-        ),
+        {
+            "name": "testvm",
+            "namespace": DEFAULT_NAMESPACE,
+            "uid": "f8abae7c-d792-4b9b-af95-62d322ae5bc1",
+        },
         host_format,
         namespace_group,
     )

--- a/tests/unit/plugins/inventory/test_kubevirt_parse.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_parse.py
@@ -13,39 +13,151 @@ from ansible_collections.kubevirt.core.plugins.inventory import (
 )
 
 from ansible_collections.kubevirt.core.plugins.inventory.kubevirt import (
+    InventoryOptions,
     KubeVirtInventoryException,
 )
 
 
 @pytest.mark.parametrize(
-    "cache",
+    "config_data,expected",
     [
-        True,
-        False,
+        (
+            {},
+            InventoryOptions(),
+        ),
+        (
+            {
+                "name": "test",
+            },
+            InventoryOptions(name="test"),
+        ),
+        (
+            {"name": "test", "namespaces": ["test"]},
+            InventoryOptions(name="test", namespaces=["test"]),
+        ),
+        (
+            {
+                "name": "test",
+                "namespaces": ["test"],
+                "use_service": True,
+                "create_groups": True,
+                "append_base_domain": True,
+                "base_domain": "test-domain",
+            },
+            InventoryOptions(
+                use_service=True,
+                create_groups=True,
+                append_base_domain=True,
+                base_domain="test-domain",
+                name="test",
+                namespaces=["test"],
+            ),
+        ),
+        (
+            {
+                "name": "test",
+                "namespaces": ["test"],
+                "use_service": True,
+                "create_groups": True,
+                "append_base_domain": True,
+                "base_domain": "test-domain",
+                "network_name": "test-network",
+            },
+            InventoryOptions(
+                use_service=True,
+                create_groups=True,
+                append_base_domain=True,
+                base_domain="test-domain",
+                network_name="test-network",
+                name="test",
+                namespaces=["test"],
+            ),
+        ),
+        (
+            {
+                "name": "test",
+                "namespaces": ["test"],
+                "use_service": True,
+                "create_groups": True,
+                "append_base_domain": True,
+                "base_domain": "test-domain",
+                "interface_name": "test-interface",
+            },
+            InventoryOptions(
+                use_service=True,
+                create_groups=True,
+                append_base_domain=True,
+                base_domain="test-domain",
+                network_name="test-interface",
+                name="test",
+                namespaces=["test"],
+            ),
+        ),
     ],
 )
-def test_parse(mocker, inventory, cache):
-    path = "/testpath"
-    cache_prefix = "test-prefix"
-    config_data = {"host_format": "test-format"}
-
-    mocker.patch.dict(inventory._cache, {cache_prefix: {"test-key": "test-value"}})
-    get_cache_prefix = mocker.patch.object(
-        inventory, "_get_cache_prefix", return_value=cache_prefix
-    )
+def test_config_data_to_opts(mocker, inventory, config_data, expected):
     read_config_data = mocker.patch.object(
         inventory, "_read_config_data", return_value=config_data
     )
+    mocker.patch.object(inventory, "get_cache_key")
+    mocker.patch.object(inventory, "get_option")
+    mocker.patch.object(kubevirt, "get_api_client")
+    mocker.patch.object(inventory, "fetch_objects")
+    populate_inventory = mocker.patch.object(inventory, "populate_inventory")
+
+    inventory.parse(None, None, "", False)
+
+    populate_inventory.assert_called_once_with(mocker.ANY, expected)
+
+
+@pytest.mark.parametrize(
+    "cache_parse,cache_option,cache_data,expected",
+    [
+        (True, True, {"test-key": {"something": "something"}}, True),
+        (None, True, {"test-key": {"something": "something"}}, True),
+        (False, True, {"test-key": {"something": "something"}}, False),
+        (True, False, {"test-key": {"something": "something"}}, False),
+        (None, False, {"test-key": {"something": "something"}}, False),
+        (False, False, {"test-key": {"something": "something"}}, False),
+        (True, True, {"test-key2": {"something": "something"}}, False),
+        (None, True, {"test-key2": {"something": "something"}}, False),
+    ],
+)
+def test_use_of_cache(
+    mocker, inventory, cache_parse, cache_option, cache_data, expected
+):
+    path = "/testpath"
+    config_data = {"host_format": "test-format"}
+
+    mocker.patch.dict(inventory._cache, cache_data)
+
+    read_config_data = mocker.patch.object(
+        inventory, "_read_config_data", return_value=config_data
+    )
+    get_cache_key = mocker.patch.object(
+        inventory, "get_cache_key", return_value="test-key"
+    )
+    get_option = mocker.patch.object(inventory, "get_option", return_value=cache_option)
+    get_api_client = mocker.patch.object(kubevirt, "get_api_client")
     fetch_objects = mocker.patch.object(inventory, "fetch_objects")
+    populate_inventory = mocker.patch.object(inventory, "populate_inventory")
 
-    inventory.parse(None, None, path, cache)
+    if cache_parse is None:
+        inventory.parse(None, None, path)
+    else:
+        inventory.parse(None, None, path, cache_parse)
 
-    get_cache_prefix.assert_called_once_with(path)
+    opts = InventoryOptions(config_data=config_data)
+    get_cache_key.assert_called_once_with(path)
+    get_option.assert_called_once_with("cache")
     read_config_data.assert_called_once_with(path)
-    if cache:
+    if expected:
+        get_api_client.assert_not_called()
         fetch_objects.assert_not_called()
     else:
-        fetch_objects.assert_called_once_with(config_data)
+        get_api_client.assert_called_once_with(**config_data)
+        fetch_objects.assert_called_once_with(mocker.ANY, opts)
+    populate_inventory.assert_called_once_with(mocker.ANY, opts)
 
 
 @pytest.mark.parametrize(
@@ -57,8 +169,10 @@ def test_parse(mocker, inventory, cache):
 )
 def test_k8s_client_missing(mocker, inventory, present):
     mocker.patch.object(kubevirt, "HAS_K8S_MODULE_HELPER", present)
-    mocker.patch.object(inventory, "_get_cache_prefix")
-    mocker.patch.object(inventory, "_read_config_data")
+    mocker.patch.object(kubevirt, "get_api_client")
+    mocker.patch.object(inventory, "_read_config_data", return_value={})
+    mocker.patch.object(inventory, "get_cache_key")
+    mocker.patch.object(inventory, "get_option")
     fetch_objects = mocker.patch.object(inventory, "fetch_objects")
 
     if present:

--- a/tests/unit/plugins/inventory/test_kubevirt_populate_inventory_from_namespace.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_populate_inventory_from_namespace.py
@@ -83,7 +83,7 @@ def test_populate_inventory_from_namespace(
 ):
     _vms = {vm["metadata"]["name"]: vm for vm in vms}
     _vmis = {vmi["metadata"]["name"]: vmi for vmi in vmis}
-    opts = InventoryOptions()
+    opts = InventoryOptions(name="test")
 
     def format_hostname(obj):
         return opts.host_format.format(
@@ -99,6 +99,7 @@ def test_populate_inventory_from_namespace(
             f"namespace_{DEFAULT_NAMESPACE}",
         )
 
+    obj_is_valid_calls = []
     add_host_side_effects = []
     add_host_calls = []
     set_vars_from_vm_calls = []
@@ -108,33 +109,27 @@ def test_populate_inventory_from_namespace(
     # For each VM add the expected calls
     # Also add expected calls for VMIs for which a VM exists
     for name, vm in _vms.items():
+        obj_is_valid_calls.append(mocker.call(vm))
         hostname = format_hostname(vm)
         add_host_side_effects.append(hostname)
         add_host_calls.append(add_host_call(vm))
         set_vars_from_vm_calls.append(mocker.call(hostname, vm, opts))
         if name in _vmis.keys():
-            set_vars_from_vmi_calls.append(mocker.call(hostname, _vmis[name], [], opts))
+            set_vars_from_vmi_calls.append(mocker.call(hostname, _vmis[name], {}, opts))
         set_composable_vars_calls.append(mocker.call(hostname))
 
     # For each VMI add the expected calls
     # Do not add for VMIs for which a VM exists
     for name, vmi in _vmis.items():
+        obj_is_valid_calls.append(mocker.call(vmi))
         if name not in _vms.keys():
             hostname = format_hostname(vmi)
             add_host_side_effects.append(hostname)
             add_host_calls.append(add_host_call(vmi))
-            set_vars_from_vmi_calls.append(mocker.call(hostname, vmi, [], opts))
+            set_vars_from_vmi_calls.append(mocker.call(hostname, vmi, {}, opts))
             set_composable_vars_calls.append(mocker.call(hostname))
 
-    get_vms_for_namespace = mocker.patch.object(
-        inventory, "get_vms_for_namespace", return_value=_vms.values()
-    )
-    get_vmis_for_namespace = mocker.patch.object(
-        inventory, "get_vmis_for_namespace", return_value=_vmis.values()
-    )
-    get_ssh_services_for_namespace = mocker.patch.object(
-        inventory, "get_ssh_services_for_namespace", return_value=[]
-    )
+    obj_is_valid = mocker.patch.object(inventory, "obj_is_valid", return_value=True)
     add_host = mocker.patch.object(
         inventory, "add_host", side_effect=add_host_side_effects
     )
@@ -142,23 +137,20 @@ def test_populate_inventory_from_namespace(
     set_vars_from_vmi = mocker.patch.object(inventory, "set_vars_from_vmi")
     set_composable_vars = mocker.patch.object(inventory, "set_composable_vars")
 
-    inventory.populate_inventory_from_namespace(None, "test", DEFAULT_NAMESPACE, opts)
-
-    # These should always get called once
-    get_vms_for_namespace.assert_called_once_with(None, DEFAULT_NAMESPACE, opts)
-    get_vmis_for_namespace.assert_called_once_with(None, DEFAULT_NAMESPACE, opts)
+    inventory.populate_inventory_from_namespace(
+        DEFAULT_NAMESPACE, {"vms": vms, "vmis": vmis, "services": {}}, opts
+    )
 
     # Assert it tries to add the expected vars for all provided VMs/VMIs
+    obj_is_valid.assert_has_calls(obj_is_valid_calls)
     set_vars_from_vm.assert_has_calls(set_vars_from_vm_calls)
     set_vars_from_vmi.assert_has_calls(set_vars_from_vmi_calls)
     set_composable_vars.assert_has_calls(set_composable_vars_calls)
 
     # If no VMs or VMIs were provided the function should not add any groups
     if vms or vmis:
-        get_ssh_services_for_namespace.assert_called_once_with(None, DEFAULT_NAMESPACE)
         assert list(groups.keys()) == ["test", f"namespace_{DEFAULT_NAMESPACE}"]
     else:
-        get_ssh_services_for_namespace.assert_not_called()
         assert not list(groups.keys())
 
     # Assert the expected amount of hosts was added

--- a/tests/unit/plugins/inventory/test_kubevirt_populate_inventory_from_namespace.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_populate_inventory_from_namespace.py
@@ -8,9 +8,6 @@ __metaclass__ = type
 
 import pytest
 
-from addict import Dict
-
-
 from ansible_collections.kubevirt.core.plugins.inventory.kubevirt import (
     InventoryOptions,
 )
@@ -25,6 +22,8 @@ VM1 = {
         "namespace": DEFAULT_NAMESPACE,
         "uid": "940003aa-0160-4b7e-9e55-8ec3df72047f",
     },
+    "spec": {},
+    "status": {},
 }
 
 VM2 = {
@@ -33,6 +32,8 @@ VM2 = {
         "namespace": DEFAULT_NAMESPACE,
         "uid": "c2c68de5-b9d7-4c25-872f-462e7245b3e6",
     },
+    "spec": {},
+    "status": {},
 }
 
 VMI1 = {
@@ -41,6 +42,7 @@ VMI1 = {
         "namespace": DEFAULT_NAMESPACE,
         "uid": "a84319a9-db31-4a36-9b66-3e387578f871",
     },
+    "spec": {},
     "status": {
         "interfaces": [{"ipAddress": "10.10.10.10"}],
     },
@@ -52,6 +54,7 @@ VMI2 = {
         "namespace": DEFAULT_NAMESPACE,
         "uid": "fd35700a-9cbe-488b-8f32-7adbe57eadc2",
     },
+    "spec": {},
     "status": {
         "interfaces": [{"ipAddress": "10.10.10.10"}],
     },
@@ -78,20 +81,20 @@ VMI2 = {
 def test_populate_inventory_from_namespace(
     mocker, inventory, groups, vms, vmis, expected
 ):
-    _vms = {vm["metadata"]["name"]: Dict(vm) for vm in vms}
-    _vmis = {vmi["metadata"]["name"]: Dict(vmi) for vmi in vmis}
+    _vms = {vm["metadata"]["name"]: vm for vm in vms}
+    _vmis = {vmi["metadata"]["name"]: vmi for vmi in vmis}
     opts = InventoryOptions()
 
     def format_hostname(obj):
         return opts.host_format.format(
-            namespace=obj.metadata.namespace,
-            name=obj.metadata.name,
-            uid=obj.metadata.uid,
+            namespace=obj["metadata"]["namespace"],
+            name=obj["metadata"]["name"],
+            uid=obj["metadata"]["uid"],
         )
 
     def add_host_call(obj):
         return mocker.call(
-            obj,
+            obj["metadata"],
             opts.host_format,
             f"namespace_{DEFAULT_NAMESPACE}",
         )

--- a/tests/unit/plugins/inventory/test_kubevirt_set_ansible_host_and_port.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_set_ansible_host_and_port.py
@@ -8,8 +8,6 @@ __metaclass__ = type
 
 import pytest
 
-from addict import Dict
-
 from ansible_collections.kubevirt.core.plugins.inventory.kubevirt import (
     InventoryOptions,
 )
@@ -29,7 +27,7 @@ def test_use_ip_address_by_default(mocker, inventory, opts):
     hostname = "default-testvm"
     ip_address = "1.1.1.1"
 
-    inventory.set_ansible_host_and_port(Dict(), hostname, ip_address, None, opts)
+    inventory.set_ansible_host_and_port({}, hostname, ip_address, None, opts)
 
     set_variable.assert_has_calls(
         [
@@ -50,12 +48,10 @@ def test_kube_secondary_dns(mocker, inventory, base_domain):
     set_variable = mocker.patch.object(inventory.inventory, "set_variable")
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {
-            "metadata": {"name": "testvm", "namespace": "default"},
-            "status": {"interfaces": [{"name": "awesome"}]},
-        }
-    )
+    vmi = {
+        "metadata": {"name": "testvm", "namespace": "default"},
+        "status": {"interfaces": [{"name": "awesome"}]},
+    }
 
     inventory.set_ansible_host_and_port(
         vmi,
@@ -85,12 +81,10 @@ def test_kube_secondary_dns_precedence_over_service(mocker, inventory):
     set_variable = mocker.patch.object(inventory.inventory, "set_variable")
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {
-            "metadata": {"name": "testvm", "namespace": "default"},
-            "status": {"interfaces": [{"name": "awesome"}]},
-        }
-    )
+    vmi = {
+        "metadata": {"name": "testvm", "namespace": "default"},
+        "status": {"interfaces": [{"name": "awesome"}]},
+    }
 
     inventory.set_ansible_host_and_port(
         vmi,
@@ -170,13 +164,11 @@ def test_service(mocker, inventory, service, expected_host, expected_port):
     set_variable = mocker.patch.object(inventory.inventory, "set_variable")
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {
-            "status": {
-                "nodeName": "testnode.example.com",
-            },
-        }
-    )
+    vmi = {
+        "status": {
+            "nodeName": "testnode.example.com",
+        },
+    }
 
     inventory.set_ansible_host_and_port(
         vmi,
@@ -198,13 +190,11 @@ def test_service_append_base_domain(mocker, inventory):
     set_variable = mocker.patch.object(inventory.inventory, "set_variable")
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {
-            "status": {
-                "nodeName": "testnode",
-            },
-        }
-    )
+    vmi = {
+        "status": {
+            "nodeName": "testnode",
+        },
+    }
     service = {
         "spec": {
             "type": "NodePort",
@@ -243,13 +233,11 @@ def test_service_fallback(mocker, inventory, host, port):
     mocker.patch.object(inventory, "get_port_from_service", return_value=port)
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {
-            "status": {
-                "nodeName": "testnode",
-            },
-        }
-    )
+    vmi = {
+        "status": {
+            "nodeName": "testnode",
+        },
+    }
     inventory.set_ansible_host_and_port(
         vmi,
         hostname,
@@ -271,7 +259,7 @@ def test_no_service_if_network_name(mocker, inventory):
 
     hostname = "default-testvm"
     inventory.set_ansible_host_and_port(
-        Dict(),
+        {},
         hostname,
         "1.2.3.4",
         {"something": "something"},

--- a/tests/unit/plugins/inventory/test_kubevirt_set_vars_from_vmi.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_set_vars_from_vmi.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from addict import Dict
-
 from ansible_collections.kubevirt.core.plugins.inventory.kubevirt import (
     InventoryOptions,
     LABEL_KUBEVIRT_IO_DOMAIN,
@@ -20,7 +18,7 @@ def test_ignore_vmi_without_interface(mocker, inventory):
         inventory, "set_ansible_host_and_port"
     )
 
-    vmi = Dict({"status": {}})
+    vmi = {"status": {}}
     inventory.set_vars_from_vmi("default-testvm", vmi, {}, InventoryOptions())
 
     set_ansible_host_and_port.assert_not_called()
@@ -33,9 +31,10 @@ def test_use_first_interface_by_default(mocker, inventory):
     )
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {"status": {"interfaces": [{"ipAddress": "1.1.1.1"}, {"ipAddress": "2.2.2.2"}]}}
-    )
+    vmi = {
+        "metadata": {},
+        "status": {"interfaces": [{"ipAddress": "1.1.1.1"}, {"ipAddress": "2.2.2.2"}]},
+    }
     opts = InventoryOptions()
     inventory.set_vars_from_vmi(hostname, vmi, {}, opts)
 
@@ -51,16 +50,15 @@ def test_use_named_interface(mocker, inventory):
     )
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {
-            "status": {
-                "interfaces": [
-                    {"name": "first", "ipAddress": "1.1.1.1"},
-                    {"name": "second", "ipAddress": "2.2.2.2"},
-                ]
-            }
-        }
-    )
+    vmi = {
+        "metadata": {},
+        "status": {
+            "interfaces": [
+                {"name": "first", "ipAddress": "1.1.1.1"},
+                {"name": "second", "ipAddress": "2.2.2.2"},
+            ]
+        },
+    }
     opts = InventoryOptions(network_name="second")
     inventory.set_vars_from_vmi(hostname, vmi, {}, opts)
 
@@ -75,9 +73,10 @@ def test_ignore_vmi_without_named_interface(mocker, inventory):
         inventory, "set_ansible_host_and_port"
     )
 
-    vmi = Dict(
-        {"status": {"interfaces": [{"name": "somename", "ipAddress": "1.1.1.1"}]}}
-    )
+    vmi = {
+        "metadata": {},
+        "status": {"interfaces": [{"name": "somename", "ipAddress": "1.1.1.1"}]},
+    }
     inventory.set_vars_from_vmi(
         "default-testvm", vmi, {}, InventoryOptions(network_name="awesome")
     )
@@ -92,7 +91,7 @@ def test_set_winrm_if_windows(mocker, inventory):
     set_variable = mocker.patch.object(inventory.inventory, "set_variable")
 
     hostname = "default-testvm"
-    vmi = Dict({"status": {"interfaces": [{"ipAddress": "1.1.1.1"}]}})
+    vmi = {"metadata": {}, "status": {"interfaces": [{"ipAddress": "1.1.1.1"}]}}
     inventory.set_vars_from_vmi(hostname, vmi, {}, InventoryOptions())
 
     set_variable.assert_called_once_with(hostname, "ansible_connection", "winrm")
@@ -105,12 +104,10 @@ def test_service_lookup(mocker, inventory):
     )
 
     hostname = "default-testvm"
-    vmi = Dict(
-        {
-            "metadata": {"labels": {LABEL_KUBEVIRT_IO_DOMAIN: "testdomain"}},
-            "status": {"interfaces": [{"name": "somename", "ipAddress": "1.1.1.1"}]},
-        }
-    )
+    vmi = {
+        "metadata": {"labels": {LABEL_KUBEVIRT_IO_DOMAIN: "testdomain"}},
+        "status": {"interfaces": [{"name": "somename", "ipAddress": "1.1.1.1"}]},
+    }
     opts = InventoryOptions()
     service = {"metadata": {"name": "testsvc"}}
     inventory.set_vars_from_vmi(hostname, vmi, {"testdomain": service}, opts)

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -2,7 +2,6 @@
 jsonpatch
 kubernetes>=28.1.0
 PyYAML>=3.11
-addict
 pytest
 pytest-mock
 pytest-xdist


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fix inventory source caching by separating the fetching of objects and
populating the inventory. This way objects can be fetched from the K8S
API or from a configured cached and the cache related parameters on the
plugin now actually work.

To make this possible use dicts instead of ResourceFields where possible 
to allow easier serialization/deserialization of objects fetched from
the K8S API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Merge after #117 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Caching of inventory sources was fixed and is now working.
```
