### PR TITLE
feat(kubevirt_vm): Add support for RunStrategy

### DIFF
--- a/examples/play-create-run-strategy.yml
+++ b/examples/play-create-run-strategy.yml
@@ -1,0 +1,42 @@
+---
+- name: Playbook creating a virtual machine with multus network
+  hosts: localhost
+  tasks:
+    - name: Create VM
+      kubevirt.core.kubevirt_vm:
+        state: present
+        name: testvm
+        namespace: default
+        labels:
+          app: test
+        instancetype:
+          name: u1.medium
+        preference:
+          name: fedora
+        run_strategy: Manual
+        spec:
+          domain:
+            devices:
+              interfaces:
+                - name: default
+                  masquerade: {}
+                - name: bridge-network
+                  bridge: {}
+          networks:
+            - name: default
+              pod: {}
+            - name: bridge-network
+              multus:
+                networkName: kindexgw
+          volumes:
+            - containerDisk:
+                image: quay.io/containerdisks/fedora:latest
+              name: containerdisk
+            - cloudInitNoCloud:
+                userData: |-
+                  #cloud-config
+                  # The default username is: fedora
+                  ssh_authorized_keys:
+                    - ssh-ed25519 AAAA...
+              name: cloudinit
+        wait: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This change adds support for setting the RunStrategy of a VM.

Depending on the value set the wait condition for the VM is adjusted. For the values Always, RerunOnFailure or Once the wait condition will wait for the VM to run and be ready. For the value Halted the wait condition will wait for the VM to not exist. For the value Manual the wait condition is not set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for setting the RunStrategy of a VM
```
