### PR TITLE
e2e-setup: Use virt-operator to deploy common-instancetypes

### DIFF
--- a/hack/e2e-setup.sh
+++ b/hack/e2e-setup.sh
@@ -30,7 +30,6 @@ set_default_params() {
 
   KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v1.2.2}
   KUBEVIRT_CDI_VERSION=${KUBEVIRT_CDI_VERSION:-v1.59.0}
-  KUBEVIRT_COMMON_INSTANCETYPES_VERSION=${KUBEVIRT_COMMON_INSTANCETYPES_VERSION:-v1.0.0}
   KUBEVIRT_USE_EMULATION=${KUBEVIRT_USE_EMULATION:-"false"}
 
   CNAO_VERSION=${CNAO_VERSION:-v0.93.0}
@@ -244,7 +243,8 @@ deploy_kubevirt_containerized_data_importer() {
 
 deploy_kubevirt_common_instancetypes() {
   echo "Deploying KubeVirt common-instancetypes"
-  ${KUBECTL} apply -f "https://github.com/kubevirt/common-instancetypes/releases/download/${KUBEVIRT_COMMON_INSTANCETYPES_VERSION}/common-instancetypes-all-bundle-${KUBEVIRT_COMMON_INSTANCETYPES_VERSION}.yaml"
+  ${KUBECTL} patch kubevirt kubevirt --namespace kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["CommonInstancetypesDeploymentGate"]}}}}'
+  ${KUBECTL} wait --for=condition=Available kubevirt kubevirt --namespace=kubevirt --timeout=5m
 }
 
 deploy_cnao() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Use the bundled common-instancetypes deployed by virt-operator instead of deploying common-instancetypes manually.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
