### PR TITLE
chore: Bump tested Ansible and Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,32 @@ jobs:
             "python-version": "3.12"
           },
           {
+            "ansible-version": "stable-2.15",
+            "python-version": "3.13"
+          },
+          {
             "ansible-version": "stable-2.16",
             "python-version": "3.9"
           },
           {
+            "ansible-version": "stable-2.16",
+            "python-version": "3.13"
+          },
+          {
             "ansible-version": "stable-2.17",
             "python-version": "3.9"
+          },
+          {
+            "ansible-version": "stable-2.17",
+            "python-version": "3.13"
+          },
+          {
+            "ansible-version": "stable-2.18",
+            "python-version": "3.9"
+          },
+          {
+            "ansible-version": "stable-2.18",
+            "python-version": "3.10"
           },
           {
             "ansible-version": "milestone",
@@ -138,12 +158,32 @@ jobs:
             "python-version": "3.12"
           },
           {
+            "ansible-version": "stable-2.15",
+            "python-version": "3.13"
+          },
+          {
             "ansible-version": "stable-2.16",
             "python-version": "3.9"
           },
           {
+            "ansible-version": "stable-2.16",
+            "python-version": "3.13"
+          },
+          {
             "ansible-version": "stable-2.17",
             "python-version": "3.9"
+          },
+          {
+            "ansible-version": "stable-2.17",
+            "python-version": "3.13"
+          },
+          {
+            "ansible-version": "stable-2.18",
+            "python-version": "3.9"
+          },
+          {
+            "ansible-version": "stable-2.18",
+            "python-version": "3.10"
           },
           {
             "ansible-version": "milestone",

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,12 +12,32 @@ on:
               "python-version": "3.12"
             },
             {
+              "ansible-version": "stable-2.15",
+              "python-version": "3.13"
+            },
+            {
               "ansible-version": "stable-2.16",
               "python-version": "3.9"
             },
             {
+              "ansible-version": "stable-2.16",
+              "python-version": "3.13"
+            },
+            {
               "ansible-version": "stable-2.17",
               "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.17",
+              "python-version": "3.13"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.9"
+            },
+            {
+              "ansible-version": "stable-2.18",
+              "python-version": "3.10"
             },
             {
               "ansible-version": "milestone",
@@ -70,6 +90,7 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           - milestone
           - devel
         python-version:
@@ -77,6 +98,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         exclude: ${{ fromJSON(inputs.matrix_exclude) }}
         include: ${{ fromJSON(inputs.matrix_include) }}
     env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository hosts the `kubevirt.core` Ansible Collection, which provides vir
 <!--start requires_ansible -->
 ## Ansible and Python version compatibility
 
-This collection has been tested against Ansible versions **>=2.15,<=2.17** and Python versions **>=3.9,<=3.12**.
+This collection has been tested against Ansible versions **>=2.15,<=2.18** and Python versions **>=3.9,<=3.13**.
 
 See the [Ansible core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) for supported combinations.
 <!--end requires_ansible -->

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.9,<=3.12"
+  python_requires: ">=3.9,<=3.13"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Bump the tested Ansible and Python version to include Ansible 2.18 and Python 3.13.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The collection is now tested with Ansible 2.18 and Python 3.13.
```
