### PR TITLE
ci(integration): Drop common-instancetypes deployment

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -146,7 +146,6 @@ jobs:
             --configure-secondary-network \
             --deploy-kubevirt \
             --deploy-kubevirt-cdi \
-            --deploy-kubevirt-common-instancetypes \
             --deploy-cnao \
             --create-cluster \
             --create-nad


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Drop the flag for common-instancetypes deployment that was removed previously.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
