### PR TITLE
fix(ci): Exclude ansible-compat's new cache location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
       - name: Run ansible-lint
         run: |
           ansible-lint --version
-          ansible-lint -v
+          # Remove --exclude flag once ansible-lint was updated to ignore ansible-compat's new cache location
+          # See https://github.com/ansible/ansible-lint/issues/4477
+          ansible-lint -v --exclude .cache .ansible
         working-directory: ${{ env.collection_dir }}
 
       - name: Run shellcheck

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
+.ansible
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

ansible-compat 25.0.0 now stores its cache in .ansible. Ignore this location when running ansible-lint and in .gitignore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
