### PR TITLE
feat(inventory): Add unset_ansible_port option

### DIFF
--- a/tests/unit/plugins/inventory/test_kubevirt_inventory_options.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_inventory_options.py
@@ -18,6 +18,7 @@ def test_inventory_options_defaults():
     assert opts.network_name is None
     assert opts.kube_secondary_dns is False
     assert opts.use_service is True
+    assert opts.unset_ansible_port is True
     assert opts.create_groups is False
     assert opts.base_domain is None
     assert opts.append_base_domain is False
@@ -30,6 +31,7 @@ def test_inventory_options_override_defaults():
     network_name = "test-network"
     kube_secondary_dns = True
     use_service = False
+    unset_ansible_port = False
     create_groups = True
     base_domain = "test-domain.com"
     append_base_domain = True
@@ -41,6 +43,7 @@ def test_inventory_options_override_defaults():
         network_name=network_name,
         kube_secondary_dns=kube_secondary_dns,
         use_service=use_service,
+        unset_ansible_port=unset_ansible_port,
         create_groups=create_groups,
         base_domain=base_domain,
         append_base_domain=append_base_domain,
@@ -51,6 +54,7 @@ def test_inventory_options_override_defaults():
     assert opts.network_name == network_name
     assert opts.kube_secondary_dns == kube_secondary_dns
     assert opts.use_service == use_service
+    assert opts.unset_ansible_port == unset_ansible_port
     assert opts.create_groups == create_groups
     assert opts.base_domain == base_domain
     assert opts.append_base_domain == append_base_domain

--- a/tests/unit/plugins/inventory/test_kubevirt_set_ansible_host_and_port.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_set_ansible_host_and_port.py
@@ -272,3 +272,25 @@ def test_no_service_if_network_name(mocker, inventory):
             mocker.call(hostname, "ansible_port", None),
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "opts,expected",
+    [
+        (InventoryOptions(), True),
+        (InventoryOptions(unset_ansible_port=True), True),
+        (InventoryOptions(unset_ansible_port=False), False),
+    ],
+)
+def test_unset_ansible_port(mocker, inventory, opts, expected):
+    set_variable = mocker.patch.object(inventory.inventory, "set_variable")
+
+    hostname = "default-testvm"
+    ip_address = "1.1.1.1"
+
+    inventory._set_ansible_host_and_port({}, hostname, ip_address, None, opts)
+
+    calls = [mocker.call(hostname, "ansible_host", ip_address)]
+    if expected:
+        calls.append(mocker.call(hostname, "ansible_port", None))
+    set_variable.assert_has_calls(calls)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds the unset_ansible_port option to the inventory, which allows to control if the value of ansible_port should be unset if no non-default value was found.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #172 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The unset_ansible_port option was added to the inventory. It allows to control if the value of ansible_port should be unset if no non-default value was found.
```
