### PR TITLE
fix: Ensure compatibility with ansible-core >= 2.19

### DIFF
--- a/tests/unit/plugins/modules/test_kubevirt_vm.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vm.py
@@ -16,14 +16,21 @@ from ansible_collections.kubevirt.core.tests.unit.utils.ansible_module_mock impo
     AnsibleExitJson,
     exit_json,
     fail_json,
-    set_module_args,
 )
+
+# Handle import errors of patch_module_args.
+# It is only available on ansible-core >=2.19.
+try:
+    from ansible.module_utils.testing import patch_module_args
+except ImportError as e:
+    from ansible_collections.kubevirt.core.tests.unit.utils.ansible_module_mock import (
+        patch_module_args,
+    )
 
 
 def test_module_fails_when_required_args_missing(mocker):
     mocker.patch.object(AnsibleModule, "fail_json", fail_json)
-    with pytest.raises(AnsibleFailJson):
-        set_module_args({})
+    with pytest.raises(AnsibleFailJson), patch_module_args({}):
         kubevirt_vm.main()
 
 
@@ -290,8 +297,7 @@ def test_module(mocker, module_params, k8s_module_params, vm_definition, method)
         },
     )
 
-    with pytest.raises(AnsibleExitJson):
-        set_module_args(module_params)
+    with pytest.raises(AnsibleExitJson), patch_module_args(module_params):
         kubevirt_vm.main()
 
     perform_action.assert_called_once_with(

--- a/tests/unit/plugins/modules/test_kubevirt_vm_info.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vm_info.py
@@ -23,14 +23,21 @@ from ansible_collections.kubevirt.core.tests.unit.utils.ansible_module_mock impo
     AnsibleFailJson,
     exit_json,
     fail_json,
-    set_module_args,
 )
+
+# Handle import errors of patch_module_args.
+# It is only available on ansible-core >=2.19.
+try:
+    from ansible.module_utils.testing import patch_module_args
+except ImportError as e:
+    from ansible_collections.kubevirt.core.tests.unit.utils.ansible_module_mock import (
+        patch_module_args,
+    )
 
 
 def test_module_fails_when_required_args_missing(mocker):
     mocker.patch.object(AnsibleModule, "fail_json", fail_json)
-    with pytest.raises(AnsibleFailJson):
-        set_module_args({"running": False})
+    with pytest.raises(AnsibleFailJson), patch_module_args({"running": False}):
         kubevirt_vm_info.main()
 
 
@@ -96,8 +103,7 @@ def test_module(mocker, module_args, find_args):
         },
     )
 
-    with pytest.raises(AnsibleExitJson):
-        set_module_args(module_args)
+    with pytest.raises(AnsibleExitJson), patch_module_args(module_args):
         kubevirt_vm_info.main()
 
     find.assert_called_once_with(**find_args)

--- a/tests/unit/plugins/modules/test_kubevirt_vmi_info.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vmi_info.py
@@ -21,8 +21,16 @@ from ansible_collections.kubevirt.core.plugins.module_utils import (
 from ansible_collections.kubevirt.core.tests.unit.utils.ansible_module_mock import (
     AnsibleExitJson,
     exit_json,
-    set_module_args,
 )
+
+# Handle import errors of patch_module_args.
+# It is only available on ansible-core >=2.19.
+try:
+    from ansible.module_utils.testing import patch_module_args
+except ImportError as e:
+    from ansible_collections.kubevirt.core.tests.unit.utils.ansible_module_mock import (
+        patch_module_args,
+    )
 
 FIND_ARGS_DEFAULT = {
     "kind": "VirtualMachineInstance",
@@ -74,8 +82,7 @@ def test_module(mocker, module_args, find_args):
         },
     )
 
-    with pytest.raises(AnsibleExitJson):
-        set_module_args(module_args)
+    with pytest.raises(AnsibleExitJson), patch_module_args(module_args):
         kubevirt_vmi_info.main()
 
     find.assert_called_once_with(**find_args)

--- a/tests/unit/utils/ansible_module_mock.py
+++ b/tests/unit/utils/ansible_module_mock.py
@@ -10,16 +10,24 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import json
+from contextlib import contextmanager
+from json import dumps
+from typing import (
+    Any,
+    Dict,
+)
+from unittest import mock
 
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes
 
 
-def set_module_args(args):
+@contextmanager
+def patch_module_args(args: Dict[str, Any] | None = None):
     """prepare arguments so that they will be picked up during module creation"""
-    args = json.dumps({"ANSIBLE_MODULE_ARGS": args})
-    basic._ANSIBLE_ARGS = to_bytes(args)
+    args = dumps({"ANSIBLE_MODULE_ARGS": args})
+    with mock.patch.object(basic, "_ANSIBLE_ARGS", to_bytes(args)):
+        yield
 
 
 class AnsibleExitJson(Exception):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

ansible-core 2.19 changes the way templates are trusted and provides a new way of patching module args in unit tests.

With this commit the following changes are made to ensure compatibility with ansible-core >= 2.19:

- Mark inputs to composable as trusted to align with the new template trust model.
- Utilize the updated method for patching module arguments in unit tests if available.
- Replace direct access to the self._cache attribute with the inventory's cache property.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The collection now supports ansible-core >= 2.19
```
