### PR TITLE
feat(modules): Add hidden_fields argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ansible-galaxy collection install kubevirt-kubevirt.core-*.tar.gz
 <!--start collection_dependencies -->
 #### Ansible collections
 
-* [kubernetes.core](https://galaxy.ansible.com/ui/repo/published/kubernetes/core)>=3.1.0,<6.0.0
+* [kubernetes.core](https://galaxy.ansible.com/ui/repo/published/kubernetes/core)>=5.2.0,<6.0.0
 
 To install all the dependencies:
 ```bash

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ readme: README.md
 authors:
   - KubeVirt Project (kubevirt.io)
 dependencies:
-  kubernetes.core: '>=3.1.0,<6.0.0'
+  kubernetes.core: '>=5.2.0,<6.0.0'
 description: Lean Ansible bindings for KubeVirt
 license_file: LICENSE
 tags:

--- a/plugins/module_utils/diff.py
+++ b/plugins/module_utils/diff.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 Red Hat, Inc.
+# Apache License 2.0 (see LICENSE or http://www.apache.org/licenses/LICENSE-2.0)
+
+from typing import Dict, Tuple, Optional
+
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s import service
+
+
+# Copied from
+# https://github.com/ansible-collections/kubernetes.core/blob/d329e7ee42799ae9d86b54cf2c7dfc8059103504/plugins/module_utils/k8s/service.py#L493
+# Removed this once this fix was merged into kubernetes.core.
+def _diff_objects(
+    existing: Dict, new: Dict, hidden_fields: Optional[list] = None
+) -> Tuple[bool, Dict]:
+    result = {}
+    diff = service.recursive_diff(existing, new)
+    if not diff:
+        return True, result
+
+    result["before"] = service.hide_fields(diff[0], hidden_fields)
+    result["after"] = service.hide_fields(diff[1], hidden_fields)
+
+    if list(result["after"].keys()) == ["metadata"] and list(
+        result["before"].keys()
+    ) == ["metadata"]:
+        # If only metadata.generation and metadata.resourceVersion changed, ignore it
+        ignored_keys = set(["generation", "resourceVersion"])
+
+        if set(result["after"]["metadata"].keys()).issubset(ignored_keys) and set(
+            result["before"]["metadata"].keys()
+        ).issubset(ignored_keys):
+            return True, result
+
+    return False, result
+
+
+service.diff_objects = _diff_objects
+
+
+def _patch_diff_objects():
+    """_dummy is required to satisfy the unused import linter and the ansible-doc sanity check."""
+    pass

--- a/plugins/module_utils/info.py
+++ b/plugins/module_utils/info.py
@@ -43,6 +43,7 @@ def execute_info_module(module, kind, wait_condition):
             wait=module.params["wait"],
             wait_sleep=module.params["wait_sleep"],
             wait_timeout=module.params["wait_timeout"],
+            hidden_fields=module.params["hidden_fields"],
             condition=wait_condition,
         )
         module.exit_json(changed=False, **facts)

--- a/plugins/modules/kubevirt_vm.py
+++ b/plugins/modules/kubevirt_vm.py
@@ -158,6 +158,15 @@ options:
     - If set to O(force=yes), and O(state=present) is set, an existing object will be replaced.
     type: bool
     default: no
+  hidden_fields:
+    description:
+    - Hide fields matching this option in the result.
+    - An example might be O(hidden_fields=[metadata.managedFields])
+      or O(hidden_fields=[metadata.annotations[kubemacpool.io/transaction-timestamp]]).
+    type: list
+    elements: str
+    default: ['metadata.annotations[kubemacpool.io/transaction-timestamp]', metadata.managedFields]
+    version_added: 2.2.0
 
 requirements:
 - "python >= 3.9"
@@ -401,6 +410,14 @@ def arg_spec() -> Dict:
                     },
                 },
             },
+        },
+        "hidden_fields": {
+            "type": "list",
+            "elements": "str",
+            "default": [
+                "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+                "metadata.managedFields",
+            ],
         },
     }
     spec.update(deepcopy(AUTH_ARG_SPEC))

--- a/plugins/modules/kubevirt_vm.py
+++ b/plugins/modules/kubevirt_vm.py
@@ -282,6 +282,11 @@ result:
       type: str
 """
 
+# Monkey patch service.diff_objects to temporarily fix the changed logic
+from ansible_collections.kubevirt.core.plugins.module_utils.diff import (
+    _patch_diff_objects,
+)
+
 from copy import deepcopy
 from typing import Dict
 
@@ -457,4 +462,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    _patch_diff_objects()
     main()

--- a/plugins/modules/kubevirt_vm_info.py
+++ b/plugins/modules/kubevirt_vm_info.py
@@ -159,6 +159,11 @@ resources:
       type: dict
 """
 
+# Monkey patch service.diff_objects to temporarily fix the changed logic
+from ansible_collections.kubevirt.core.plugins.module_utils.diff import (
+    _patch_diff_objects,
+)
+
 from copy import deepcopy
 
 from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule import (
@@ -223,4 +228,5 @@ def main():
 
 
 if __name__ == "__main__":
+    _patch_diff_objects()
     main()

--- a/plugins/modules/kubevirt_vm_info.py
+++ b/plugins/modules/kubevirt_vm_info.py
@@ -74,6 +74,15 @@ options:
     - Ignored if O(wait) is not set.
     default: 120
     type: int
+  hidden_fields:
+    description:
+    - Hide fields matching this option in the result.
+    - An example might be O(hidden_fields=[metadata.managedFields])
+      or O(hidden_fields=[metadata.annotations[kubemacpool.io/transaction-timestamp]]).
+    type: list
+    elements: str
+    default: ['metadata.annotations[kubemacpool.io/transaction-timestamp]', metadata.managedFields]
+    version_added: 2.2.0
 
 requirements:
   - "python >= 3.9"
@@ -174,6 +183,14 @@ def arg_spec():
     """
     spec = {
         "running": {"type": "bool"},
+        "hidden_fields": {
+            "type": "list",
+            "elements": "str",
+            "default": [
+                "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+                "metadata.managedFields",
+            ],
+        },
     }
     spec.update(deepcopy(INFO_ARG_SPEC))
     spec.update(deepcopy(AUTH_ARG_SPEC))

--- a/plugins/modules/kubevirt_vmi_info.py
+++ b/plugins/modules/kubevirt_vmi_info.py
@@ -66,6 +66,15 @@ options:
     - Ignored if O(wait) is not set.
     default: 120
     type: int
+  hidden_fields:
+    description:
+    - Hide fields matching this option in the result.
+    - An example might be O(hidden_fields=[metadata.managedFields])
+      or O(hidden_fields=[metadata.annotations[kubemacpool.io/transaction-timestamp]]).
+    type: list
+    elements: str
+    default: ['metadata.annotations[kubemacpool.io/transaction-timestamp]', metadata.managedFields]
+    version_added: 2.2.0
 
 requirements:
   - "python >= 3.9"
@@ -157,7 +166,16 @@ def arg_spec():
     """
     arg_spec defines the argument spec of this module.
     """
-    spec = {}
+    spec = {
+        "hidden_fields": {
+            "type": "list",
+            "elements": "str",
+            "default": [
+                "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+                "metadata.managedFields",
+            ],
+        },
+    }
     spec.update(deepcopy(INFO_ARG_SPEC))
     spec.update(deepcopy(AUTH_ARG_SPEC))
 

--- a/plugins/modules/kubevirt_vmi_info.py
+++ b/plugins/modules/kubevirt_vmi_info.py
@@ -144,6 +144,11 @@ resources:
       type: dict
 """
 
+# Monkey patch service.diff_objects to temporarily fix the changed logic
+from ansible_collections.kubevirt.core.plugins.module_utils.diff import (
+    _patch_diff_objects,
+)
+
 from copy import deepcopy
 
 from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule import (
@@ -202,4 +207,5 @@ def main():
 
 
 if __name__ == "__main__":
+    _patch_diff_objects()
     main()

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: kubernetes.core
-    version: '>=3.1.0,<6.0.0'
+    version: '>=5.2.0,<6.0.0'

--- a/tests/unit/plugins/modules/test_kubevirt_vm.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vm.py
@@ -210,12 +210,26 @@ MODULE_PARAMS_DELETE = MODULE_PARAMS_DEFAULT | {
     "wait": True,
 }
 
+MODULE_PARAMS_HIDDEN_FIELDS = MODULE_PARAMS_DEFAULT | {
+    "name": "testvm",
+    "namespace": "default",
+    "running": False,
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
+    ],
+}
+
 K8S_MODULE_PARAMS_CREATE = MODULE_PARAMS_CREATE | {
     "generate_name": None,
     "running": None,
     "run_strategy": None,
     "resource_definition": VM_DEFINITION_CREATE,
     "wait_condition": {"type": "Ready", "status": True},
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.managedFields",
+    ],
 }
 
 K8S_MODULE_PARAMS_RUNNING = MODULE_PARAMS_RUNNING | {
@@ -223,6 +237,10 @@ K8S_MODULE_PARAMS_RUNNING = MODULE_PARAMS_RUNNING | {
     "run_strategy": None,
     "resource_definition": VM_DEFINITION_RUNNING,
     "wait_condition": {"type": "Ready", "status": True},
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.managedFields",
+    ],
 }
 
 K8S_MODULE_PARAMS_STOPPED = MODULE_PARAMS_STOPPED | {
@@ -230,6 +248,10 @@ K8S_MODULE_PARAMS_STOPPED = MODULE_PARAMS_STOPPED | {
     "run_strategy": None,
     "resource_definition": VM_DEFINITION_STOPPED,
     "wait_condition": {"type": "Ready", "status": False, "reason": "VMINotExists"},
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.managedFields",
+    ],
 }
 
 K8S_MODULE_PARAMS_HALTED = MODULE_PARAMS_HALTED | {
@@ -237,6 +259,10 @@ K8S_MODULE_PARAMS_HALTED = MODULE_PARAMS_HALTED | {
     "running": None,
     "resource_definition": VM_DEFINITION_HALTED,
     "wait_condition": {"type": "Ready", "status": False, "reason": "VMINotExists"},
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.managedFields",
+    ],
 }
 
 K8S_MODULE_PARAMS_DELETE = MODULE_PARAMS_DELETE | {
@@ -245,6 +271,17 @@ K8S_MODULE_PARAMS_DELETE = MODULE_PARAMS_DELETE | {
     "run_strategy": None,
     "resource_definition": VM_DEFINITION_RUNNING,
     "wait_condition": {"type": "Ready", "status": True},
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.managedFields",
+    ],
+}
+
+K8S_MODULE_PARAMS_HIDDEN_FIELDS = MODULE_PARAMS_HIDDEN_FIELDS | {
+    "generate_name": None,
+    "run_strategy": None,
+    "resource_definition": VM_DEFINITION_STOPPED,
+    "wait_condition": {"type": "Ready", "status": False, "reason": "VMINotExists"},
 }
 
 
@@ -280,6 +317,12 @@ K8S_MODULE_PARAMS_DELETE = MODULE_PARAMS_DELETE | {
             K8S_MODULE_PARAMS_DELETE,
             VM_DEFINITION_RUNNING,
             "delete",
+        ),
+        (
+            MODULE_PARAMS_HIDDEN_FIELDS,
+            K8S_MODULE_PARAMS_HIDDEN_FIELDS,
+            VM_DEFINITION_STOPPED,
+            "update",
         ),
     ],
 )

--- a/tests/unit/plugins/modules/test_kubevirt_vm_info.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vm_info.py
@@ -52,6 +52,10 @@ FIND_ARGS_DEFAULT = {
     "wait_sleep": 5,
     "wait_timeout": 120,
     "condition": {"type": "Ready", "status": True},
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.managedFields",
+    ],
 }
 
 FIND_ARGS_NAME_NAMESPACE = FIND_ARGS_DEFAULT | {
@@ -77,6 +81,13 @@ FIND_ARGS_STOPPED = FIND_ARGS_DEFAULT | {
     "condition": {"type": "Ready", "status": False, "reason": "VMINotExists"},
 }
 
+FIND_ARGS_HIDDEN_FIELDS = FIND_ARGS_DEFAULT | {
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
+    ],
+}
+
 
 @pytest.mark.parametrize(
     "module_args,find_args",
@@ -87,6 +98,15 @@ FIND_ARGS_STOPPED = FIND_ARGS_DEFAULT | {
         ({"field_selectors": "app=test"}, FIND_ARGS_FIELD_SELECTOR),
         ({"wait": True, "running": True}, FIND_ARGS_RUNNING),
         ({"wait": True, "running": False}, FIND_ARGS_STOPPED),
+        (
+            {
+                "hidden_fields": [
+                    "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+                    "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
+                ]
+            },
+            FIND_ARGS_HIDDEN_FIELDS,
+        ),
     ],
 )
 def test_module(mocker, module_args, find_args):

--- a/tests/unit/plugins/modules/test_kubevirt_vmi_info.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vmi_info.py
@@ -43,6 +43,10 @@ FIND_ARGS_DEFAULT = {
     "wait_sleep": 5,
     "wait_timeout": 120,
     "condition": {"type": "Ready", "status": True},
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.managedFields",
+    ],
 }
 
 FIND_ARGS_NAME_NAMESPACE = FIND_ARGS_DEFAULT | {
@@ -58,6 +62,13 @@ FIND_ARGS_FIELD_SELECTOR = FIND_ARGS_DEFAULT | {
     "field_selectors": ["app=test"],
 }
 
+FIND_ARGS_HIDDEN_FIELDS = FIND_ARGS_DEFAULT | {
+    "hidden_fields": [
+        "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+        "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
+    ],
+}
+
 
 @pytest.mark.parametrize(
     "module_args,find_args",
@@ -66,6 +77,15 @@ FIND_ARGS_FIELD_SELECTOR = FIND_ARGS_DEFAULT | {
         ({"name": "testvm", "namespace": "default"}, FIND_ARGS_NAME_NAMESPACE),
         ({"label_selectors": "app=test"}, FIND_ARGS_LABEL_SELECTOR),
         ({"field_selectors": "app=test"}, FIND_ARGS_FIELD_SELECTOR),
+        (
+            {
+                "hidden_fields": [
+                    "metadata.annotations[kubemacpool.io/transaction-timestamp]",
+                    "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
+                ]
+            },
+            FIND_ARGS_HIDDEN_FIELDS,
+        ),
     ],
 )
 def test_module(mocker, module_args, find_args):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In order to make use of new features in kubernetes.core bump its minimum
version to 5.2.0.

Add the hidden_fields argument to kubevirt_vm and kubevirt_{vm,vmi}_info
which allows to hide and ignore certain fields in the returned definition
of a VM or VMI. By default this argument is set to ignore changes to the
kubemacpool.io/transaction-timestamp annotation, which may change at any
time and cause the modules to return a changed status although nothing
has changed other than this annotation.

Fix the change detection of kubernetes.core temporarily by monkey
patching the service.diff_objects function. This fix should be removed
once it was merged into kubernetes.core. A dummy _patch_diff_objects
function is introduced to satisfy ansible linters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #145

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The hidden_fields argument was added to kubevirt_vm and kubevirt_{vm,vmi}_info which allows to hide and ignore certain fields in the returned definition of a VM or VMI.
```
