### PR TITLE
feat(inventory): Use OCP projects if available

### DIFF
--- a/tests/unit/plugins/inventory/test_kubevirt_get_resources.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_get_resources.py
@@ -63,6 +63,27 @@ def test_get_resources(inventory, client):
             },
             [DEFAULT_NAMESPACE, "test"],
         ),
+        (
+            {
+                "projects": [
+                    {"metadata": {"name": DEFAULT_NAMESPACE}},
+                    {"metadata": {"name": "testproject"}},
+                ]
+            },
+            [DEFAULT_NAMESPACE, "testproject"],
+        ),
+        (
+            {
+                "namespaces": [
+                    {"metadata": {"name": DEFAULT_NAMESPACE}},
+                    {"metadata": {"name": "test"}},
+                ],
+                "projects": [
+                    {"metadata": {"name": "testproject"}},
+                ],
+            },
+            ["testproject"],
+        ),
     ],
     indirect=["client"],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If no namespaces were specified in the inventory config try to get all available namespaces by trying to list OCP projects first. If the resource was not found (no OCP cluster) fall back to regular namespaces.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #166 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
If no namespaces were configured the inventory now tries to use OCP Projects if available.
```
