### PR TITLE
fix(kubevirt_vm): Allow switching between running and run_strategy

### DIFF
--- a/plugins/modules/kubevirt_vm.py
+++ b/plugins/modules/kubevirt_vm.py
@@ -333,7 +333,9 @@ def create_vm(params: Dict) -> Dict:
 
     if (run_strategy := params.get("run_strategy")) is not None:
         vm["spec"]["runStrategy"] = run_strategy
+        vm["spec"]["running"] = None
     else:
+        vm["spec"]["runStrategy"] = None
         vm["spec"]["running"] = (
             running if (running := params.get("running")) is not None else True
         )

--- a/tests/unit/plugins/modules/test_kubevirt_vm.py
+++ b/tests/unit/plugins/modules/test_kubevirt_vm.py
@@ -44,6 +44,7 @@ VM_DEFINITION_CREATE = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "instancetype": {"name": "u1.medium"},
         "preference": {"name": "fedora"},
         "dataVolumeTemplates": [
@@ -83,6 +84,7 @@ VM_DEFINITION_RUNNING = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "template": {
             "spec": {
                 "domain": {"devices": {}},
@@ -100,6 +102,7 @@ VM_DEFINITION_STOPPED = {
     },
     "spec": {
         "running": False,
+        "runStrategy": None,
         "template": {
             "spec": {
                 "domain": {"devices": {}},
@@ -116,6 +119,7 @@ VM_DEFINITION_HALTED = {
         "namespace": "default",
     },
     "spec": {
+        "running": None,
         "runStrategy": "Halted",
         "template": {
             "spec": {
@@ -383,6 +387,7 @@ CREATED_VM = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "template": {
             "spec": {
                 "domain": {
@@ -400,6 +405,7 @@ CREATED_VM_RUN_STRATEGY = {
         "namespace": "default",
     },
     "spec": {
+        "running": None,
         "runStrategy": "Manual",
         "template": {
             "spec": {
@@ -422,6 +428,7 @@ CREATED_VM_LABELS = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "template": {
             "metadata": {
                 "labels": {"test": "test"},
@@ -446,6 +453,7 @@ CREATED_VM_ANNOTATIONS = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "template": {
             "metadata": {
                 "annotations": {"test": "test"},
@@ -467,6 +475,7 @@ CREATED_VM_INSTANCETYPE = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "instancetype": {"name": "u1.medium"},
         "template": {
             "spec": {
@@ -486,6 +495,7 @@ CREATED_VM_PREFERENCE = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "preference": {"name": "fedora"},
         "template": {
             "spec": {
@@ -505,6 +515,7 @@ CREATED_VM_DATAVOLUMETEMPLATE = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "dataVolumeTemplates": [
             {
                 "metadata": {"name": "testdv"},
@@ -540,6 +551,7 @@ CREATED_VM_NAME = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "template": {
             "spec": {
                 "domain": {
@@ -559,6 +571,7 @@ CREATED_VM_GENERATE_NAME = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "template": {
             "spec": {
                 "domain": {
@@ -577,6 +590,7 @@ CREATED_VM_SPECS = {
     },
     "spec": {
         "running": True,
+        "runStrategy": None,
         "template": {
             "spec": {
                 "domain": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Allow switching between running and run_strategy by always clearing the other value. E.g. if run_strategy was provided then running set to None to clear it or vice versa.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #152 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix(kubevirt_vm): It is now possible to switch between running and run_strategy
```
