### PR TITLE
fix(e2e-setup.sh): Wait for CDI to be available

### DIFF
--- a/hack/e2e-setup.sh
+++ b/hack/e2e-setup.sh
@@ -239,6 +239,12 @@ deploy_kubevirt_containerized_data_importer() {
   echo "Deploying KubeVirt containerized-data-importer"
   ${KUBECTL} apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${KUBEVIRT_CDI_VERSION}/cdi-operator.yaml"
   ${KUBECTL} apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${KUBEVIRT_CDI_VERSION}/cdi-cr.yaml"
+
+  echo "Waiting for KubeVirt containerized-data-importer to be ready"
+  ${KUBECTL} wait --for=condition=Available cdi cdi --timeout=5m
+
+  echo "Successfully deployed KubeVirt containerized-data-importer:"
+  ${KUBECTL} get pods -n cdi
 }
 
 deploy_cnao() {
@@ -307,7 +313,7 @@ cleanup() {
 }
 
 usage() {
-  echo -n "$0 [--install-kind] [--install-kubectl] [--configure-inotify-limits] [--create-registry] [--create-cluster] [--deploy-kubevirt] [--deploy-cnao] [--create-nad] [--cleanup] [--namespace]"
+  echo -n "$0 [--install-kind] [--install-kubectl] [--configure-inotify-limits] [--create-registry] [--create-cluster] [--deploy-kubevirt] [--deploy-kubevirt-cdi] [--deploy-cnao] [--create-nad] [--cleanup] [--namespace]"
 }
 
 set_default_options() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Wait for CDI to be available after deploying it.

Also add the missing --deploy-kubevirt-cdi flag to the usage help.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
