### PR TITLE
Bump dependency on kubernetes.core and collection version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ansible-galaxy collection install kubevirt-kubevirt.core-*.tar.gz
 <!--start collection_dependencies -->
 #### Ansible collections
 
-* [kubernetes.core](https://galaxy.ansible.com/ui/repo/published/kubernetes/core)>=5.2.0,<6.0.0
+* [kubernetes.core](https://galaxy.ansible.com/ui/repo/published/kubernetes/core)>=5.2.0,<7.0.0
 
 To install all the dependencies:
 ```bash

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -247,3 +247,8 @@ releases:
       release_summary: This is a maintenance release to trigger a rebuild. No functional
         changes.
     release_date: '2025-05-20'
+  2.2.3:
+    changes:
+      release_summary: This release ensures compatibility with kubernets.core >=5.2.0,<7.0.0.
+        changes.
+    release_date: '2025-06-04'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: kubevirt
 name: core
-version: "2.2.2"
+version: "2.2.3"
 readme: README.md
 authors:
   - KubeVirt Project (kubevirt.io)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ readme: README.md
 authors:
   - KubeVirt Project (kubevirt.io)
 dependencies:
-  kubernetes.core: '>=5.2.0,<6.0.0'
+  kubernetes.core: '>=5.2.0,<7.0.0'
 description: Lean Ansible bindings for KubeVirt
 license_file: LICENSE
 tags:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: kubernetes.core
-    version: '>=5.2.0,<6.0.0'
+    version: '>=5.2.0,<7.0.0'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This bumps the dependency on kubernetes.core to >=5.2.0,<7.0.0 and the version and changelog of the collection to 2.2.3.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #191 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bumps the dependency on kubernetes.core to >=5.2.0,<7.0.0
```
