### PR TITLE
fix: pass user-configured `strict` option to `_set_composite_vars` in kubevirt inventory plugin

### DIFF
--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -920,7 +920,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             trust_compose_groups(self.get_option("compose")),
             hostvars,
             hostname,
-            strict=True,
+            strict=strict,
         )
         self._add_host_to_composed_groups(
             trust_compose_groups(self.get_option("groups")),

--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_set_composable_vars.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_set_composable_vars.py
@@ -61,3 +61,30 @@ def test_set_composable_vars(
     assert host in groups["block_migratable_vmis"]["children"]
     assert "fedora_40" in groups
     assert host in groups["fedora_40"]["children"]
+
+
+def test_set_composable_vars_strict_false_ignores_compose_errors(
+    inventory,
+    groups,
+    hosts,
+):
+    inventory._options = {
+        "compose": {"custom_label": "vmi_nonexistent_label"},
+        "groups": {},
+        "keyed_groups": [],
+        "strict": False,
+    }
+    inventory._populate_inventory(
+        {
+            "default_hostname": "test",
+            "cluster_domain": "test.com",
+            "namespaces": {
+                "default": {"vms": [], "vmis": [VMI], "services": {}},
+            },
+        },
+        InventoryOptions(),
+    )
+
+    host = f"{DEFAULT_NAMESPACE}-testvmi"
+    assert host in hosts
+    assert "custom_label" not in hosts[host]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fixes the KubeVirt inventory plugin to correctly respect the strict configuration option for compose variables. Previously, the strict parameter was hardcoded to True in the _set_composite_vars() call, causing errors in compose expressions to always raise exceptions even when users configured strict: false. This fix ensures consistent behavior across all composable variable types (compose, groups, and keyed_groups).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is a one-line change on line 923 of plugins/inventory/kubevirt.py, replacing strict=True with strict=strict to match the behavior of the other two composable calls in the same method (_add_host_to_composed_groups and _add_host_to_keyed_groups, which already correctly use the user-configured value).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```