### PR TITLE
chore(ci): add ansible 2.21 and fix docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,14 @@ jobs:
             "python-version": "3.11"
           },
           {
+            "ansible-version": "stable-2.21",
+            "python-version": "3.10"
+          },
+          {
+            "ansible-version": "stable-2.21",
+            "python-version": "3.11"
+          },
+          {
             "ansible-version": "milestone",
             "python-version": "3.10"
           },
@@ -201,6 +209,14 @@ jobs:
           },
           {
             "ansible-version": "stable-2.20",
+            "python-version": "3.11"
+          },
+          {
+            "ansible-version": "stable-2.21",
+            "python-version": "3.10"
+          },
+          {
+            "ansible-version": "stable-2.21",
             "python-version": "3.11"
           },
           {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.x
+          python-version: "3.13"
           cache: pip
 
       - name: Install doc dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,6 +48,14 @@ on:
               "python-version": "3.11"
             },
             {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.10"
+            },
+            {
+              "ansible-version": "stable-2.21",
+              "python-version": "3.11"
+            },
+            {
               "ansible-version": "milestone",
               "python-version": "3.10"
             },
@@ -100,6 +108,7 @@ jobs:
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - milestone
           - devel
         python-version:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository hosts the `kubevirt.core` Ansible Collection, which provides vir
 <!--start requires_ansible -->
 ## Ansible and Python version compatibility
 
-This collection has been tested against Ansible versions **>=2.16,<=2.20** and Python versions **>=3.10,<=3.14**.
+This collection has been tested against Ansible versions **>=2.16,<=2.21** and Python versions **>=3.10,<=3.14**.
 
 See the [Ansible core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) for supported combinations.
 <!--end requires_ansible -->


### PR DESCRIPTION
**What this PR does / why we need it**:
Add ansible stable-2.21 to CI and integration test matrices and update the README to reflect the new tested version range.
Pin Python to 3.13 for the docs workflow to fix the build - Python 3.14 removed `pkg_resources`, which breaks `ansible_basic_sphinx_ext`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Added ansible-core 2.21 to the tested versions
```