### PR TITLE
fix(ci): exclude Python 3.12 from ansible-core devel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,10 @@ jobs:
           {
             "ansible-version": "devel",
             "python-version": "3.11"
+          },
+          {
+            "ansible-version": "devel",
+            "python-version": "3.12"
           }
         ]
 
@@ -234,6 +238,10 @@ jobs:
           {
             "ansible-version": "devel",
             "python-version": "3.11"
+          },
+          {
+            "ansible-version": "devel",
+            "python-version": "3.12"
           }
         ]
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,6 +70,10 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.11"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.12"
             }
           ]
         required: false


### PR DESCRIPTION
**What this PR does / why we need it**:
ansible-core `devel` now requires Python >= 3.13. This excludes Python 3.12
from `devel` CI matrix jobs (sanity, unit-source, integration) to fix the
resulting failures. `devel` jobs continue to run on py3.13 and py3.14.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```