### PR TITLE
docs: clarify local tox setup and unit test matrix usage

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -14,11 +14,23 @@
 
 ## Development environment
 
-To develop and to run tests you need to install `tox` and `tox-ansible` on
-your machine.
+Install `tox` (version 4 or newer) and `tox-ansible`:
 
 ```
-pip install --user tox tox-ansible
+pip install --user 'tox>=4' tox-ansible
+```
+
+With `--user`, `tox` is in `~/.local/bin`. Put it first on `PATH` before
+`make` targets that use `tox` (`build-venv`, `test-unit`, `test-sanity`):
+
+```
+export PATH="$HOME/.local/bin:$PATH"    # whole shell session
+```
+
+or
+
+```
+PATH="$HOME/.local/bin:$PATH" make <target>    # command only
 ```
 
 ### Virtualenv for development

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,6 +27,16 @@ Run unit tests with `tox-ansible` like so:
 make test-unit
 ```
 
+`make test-unit` runs the full matrix in parallel. For local development, run
+one environment instead. If you installed tox with `--user`, put `~/.local/bin`
+first on `PATH` before running `tox`. See [developing.md](developing.md).
+
+```
+tox -e unit-py3.11-2.16 --ansible --conf tox-ansible.ini
+```
+
+List available unit envs with `tox -f unit --ansible --conf tox-ansible.ini -l`.
+
 ### Running tests with ansible-test
 
 In order to test changes with `ansible-test`, it is recommended to bind mount
@@ -135,4 +145,3 @@ ansible-playbook -i examples/inventory.kubevirt.yml examples/play-delete.yml
 # terminate the environment
 hack/e2e-setup.sh --cleanup
 ```
-


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Document tox 4 requirement and PATH fix for --user installs so make targets use the correct tox binary. Describe how to list, filter and use selective unit test environments instead of running the full matrix. These small gaps are identified while testing locally

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Documentation only.
Clarifies local tox 4 + PATH setup and selective unit test runs.
No functional changes.

Verified locally: make build-venv and tox -f unit py3.11 2.16 --ansible --conf tox-ansible.ini with PATH
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE

```
