### PR TITLE
fix(ci): update e2e-setup versions, pin K8s 1.35

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -156,7 +156,7 @@ jobs:
         if: inputs.ansible_test_targets != ''
         uses: helm/kind-action@v1.14.0
         with:
-          version: v0.31.0
+          version: v0.32.0
           install_only: true
 
       - name: Deploy kubevirt

--- a/hack/e2e-setup.sh
+++ b/hack/e2e-setup.sh
@@ -23,12 +23,13 @@ set_default_params() {
   BIN_DIR=${BIN_DIR:-$DIR/../bin}
 
   KIND=${KIND:-$BIN_DIR/kind}
-  KIND_VERSION=${KIND_VERSION:-v0.31.0}
+  KIND_VERSION=${KIND_VERSION:-v0.32.0}
+  KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-kindest/node:v1.35.5}
 
   KUBECTL=${KUBECTL:-$BIN_DIR/kubectl}
   KUBECTL_VERSION=${KUBECTL_VERSION:-v1.35.1}
 
-  KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v1.8.2}
+  KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v1.8.3}
   KUBEVIRT_CDI_VERSION=${KUBEVIRT_CDI_VERSION:-v1.65.0}
   KUBEVIRT_USE_EMULATION=${KUBEVIRT_USE_EMULATION:-"false"}
 
@@ -127,7 +128,7 @@ create_registry() {
 create_cluster() {
   if [ "${OPT_CREATE_REGISTRY}" == true ]; then
     echo "Creating kind cluster with containerd registry config dir enabled"
-    cat <<EOF | DOCKER_HOST=unix://${_cri_socket} ${KIND} create cluster --wait 2m --name "${CLUSTER_NAME}" --config=-
+    cat <<EOF | DOCKER_HOST=unix://${_cri_socket} ${KIND} create cluster --wait 2m --name "${CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
@@ -137,7 +138,7 @@ containerdConfigPatches:
 EOF
   else
     echo "Creating cluster with kind"
-    DOCKER_HOST=unix://${_cri_socket} ${KIND} create cluster --wait 2m --name "${CLUSTER_NAME}"
+    DOCKER_HOST=unix://${_cri_socket} ${KIND} create cluster --wait 2m --name "${CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}"
   fi
 
   echo "Waiting for the network to be ready"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates kind v0.31.0 -> v0.32.0 and KubeVirt v1.8.2 -> v1.8.3.
Pins the kind node image to K8s 1.35 since KubeVirt v1.8 does not yet support K8s 1.36 (kind v0.32.0 defaults to 1.36). Adds a `KIND_NODE_IMAGE` variable to `e2e-setup.sh` for explicit control of the Kubernetes version.

Supersedes #243, which failed CI because kind v0.32.0 defaults to K8s 1.36 and VMs timed out during startup.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```