### PR TITLE
tests(inventory): cover existing ansible_connection and service selection

### DIFF
--- a/tests/unit/plugins/inventory/blackbox/test_kubevirt_win_ansible_connection.py
+++ b/tests/unit/plugins/inventory/blackbox/test_kubevirt_win_ansible_connection.py
@@ -96,6 +96,34 @@ SVC_LB_SSH = merge_dicts(
         },
     },
 )
+SVC_LB_SSH_2222 = merge_dicts(
+    SVC_LB_SSH,
+    {
+        "spec": {
+            "ports": [
+                {
+                    "protocol": "TCP",
+                    "port": 2222,
+                    "targetPort": 22,
+                },
+            ],
+        },
+    },
+)
+SVC_LB_WINRM_HTTPS_59861 = merge_dicts(
+    SVC_LB_WINRM_HTTPS,
+    {
+        "spec": {
+            "ports": [
+                {
+                    "protocol": "TCP",
+                    "port": 59861,
+                    "targetPort": 5986,
+                },
+            ],
+        },
+    },
+)
 
 
 @pytest.mark.parametrize(
@@ -155,3 +183,45 @@ def test_default_win_ansible_connection(
     else:
         assert hosts[host]["ansible_host"] == "10.10.10.10"
         assert hosts[host]["ansible_port"] is None
+
+
+@pytest.mark.parametrize(
+    "default_win_ansible_connection,expected_port",
+    [
+        ("winrm", 59861),
+        ("ssh", 2222),
+    ],
+)
+def test_default_win_ansible_connection_picks_service_by_protocol(
+    inventory,
+    hosts,
+    default_win_ansible_connection,
+    expected_port,
+):
+    inventory._populate_inventory(
+        {
+            "default_hostname": "test",
+            "cluster_domain": "test.com",
+            "namespaces": {
+                "default": {
+                    "vms": [],
+                    "vmis": [WINDOWS_VMI_1],
+                    "services": {
+                        "testdomain": [
+                            SVC_LB_SSH_2222,
+                            SVC_LB_WINRM_HTTPS_59861,
+                        ]
+                    },
+                }
+            },
+        },
+        InventoryOptions(
+            use_service=True,
+            default_win_ansible_connection=default_win_ansible_connection,
+        ),
+    )
+
+    host = f"{DEFAULT_NAMESPACE}-{WINDOWS_VMI_1['metadata']['name']}"
+    assert hosts[host]["ansible_connection"] == default_win_ansible_connection
+    assert hosts[host]["ansible_host"] == "192.168.1.100"
+    assert hosts[host]["ansible_port"] == expected_port

--- a/tests/unit/plugins/inventory/test_kubevirt_set_vars_from_vmi.py
+++ b/tests/unit/plugins/inventory/test_kubevirt_set_vars_from_vmi.py
@@ -121,6 +121,56 @@ def test_set_connection_if_windows(mocker, inventory, default_win_ansible_connec
 
 
 @pytest.mark.parametrize(
+    "existing_ansible_connection,default_win_ansible_connection,target_port",
+    [
+        ("ssh", "winrm", 22),
+        ("winrm", "ssh", 5986),
+    ],
+)
+def test_respect_existing_ansible_connection(
+    mocker,
+    inventory,
+    existing_ansible_connection,
+    default_win_ansible_connection,
+    target_port,
+):
+    mocker.patch.object(inventory, "_set_common_vars")
+    mocker.patch.object(inventory, "_is_windows", return_value=True)
+    set_ansible_host_and_port = mocker.patch.object(
+        inventory, "_set_ansible_host_and_port"
+    )
+    mocker.patch.object(
+        inventory.inventory,
+        "get_host",
+        return_value=mocker.Mock(
+            get_vars=mocker.Mock(
+                return_value={"ansible_connection": existing_ansible_connection}
+            )
+        ),
+    )
+    set_variable = mocker.patch.object(inventory.inventory, "set_variable")
+
+    hostname = "default-testvm"
+    vmi = {
+        "metadata": {"labels": {LABEL_KUBEVIRT_IO_DOMAIN: "testdomain"}},
+        "status": {"interfaces": [{"ipAddress": "1.1.1.1"}]},
+    }
+    service = {
+        "metadata": {"name": "testsvc"},
+        "spec": {"ports": [{"targetPort": target_port}]},
+    }
+    opts = InventoryOptions(
+        default_win_ansible_connection=default_win_ansible_connection
+    )
+    inventory._set_vars_from_vmi(hostname, vmi, {"testdomain": [service]}, opts)
+
+    set_variable.assert_not_called()
+    set_ansible_host_and_port.assert_called_once_with(
+        vmi, hostname, "1.1.1.1", service, opts
+    )
+
+
+@pytest.mark.parametrize(
     "is_windows,target_port",
     [
         (False, 22),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adding 2 additional tests cases for :

Existing ansible_connection is preserved :  when a host already has ansible_connection set ( via group vars or compose) the plugin must not overwrite it with the default. 

Service selection with both SSH and WinRM exposed:  when a Windows VM has both an SSH Service (targetPort 22) and a WinRM Service (targetPort 5986), the plugin must pick the Service that matches the connection type and  not the first one in the list...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Test-only change. No plugin code modified.
Tested locally 
tests/unit/plugins/inventory/blackbox/test_kubevirt_win_ansible_connection.py::test_default_win_ansible_connection_picks_service_by_protocol[winrm-59861] PASSED
tests/unit/plugins/inventory/blackbox/test_kubevirt_win_ansible_connection.py::test_default_win_ansible_connection_picks_service_by_protocol[ssh-2222] PASSED
tests/unit/plugins/inventory/test_kubevirt_set_vars_from_vmi.py::test_respect_existing_ansible_connection[ssh-winrm-22] PASSED
tests/unit/plugins/inventory/test_kubevirt_set_vars_from_vmi.py::test_respect_existing_ansible_connection[winrm-ssh-5986] PASSED

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE

```
