### PR TITLE
fix(ci): exclude Python 3.12 from milestone test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,10 @@ jobs:
             "python-version": "3.11"
           },
           {
+            "ansible-version": "milestone",
+            "python-version": "3.12"
+          },
+          {
             "ansible-version": "devel",
             "python-version": "3.10"
           },
@@ -230,6 +234,10 @@ jobs:
           {
             "ansible-version": "milestone",
             "python-version": "3.11"
+          },
+          {
+            "ansible-version": "milestone",
+            "python-version": "3.12"
           },
           {
             "ansible-version": "devel",

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,6 +64,10 @@ on:
               "python-version": "3.11"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.12"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.10"
             },


### PR DESCRIPTION
**What this PR does / why we need it**:
Excludes Python 3.12 from the `milestone` ansible-core test matrix.
The ansible-core milestone branch now requires Python `>=3.13`, causing
all `py3.12 / milestone` CI jobs to fail with:
`Package 'ansible-core' requires a different Python: 3.12 not in '>=3.13'`

See https://github.com/kubevirt/kubevirt.core/actions/runs/28644309649

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The exclusion is added in three places to keep them in sync:
- `ci.yml` sanity `matrix_exclude`
- `ci.yml` unit-source `matrix_exclude`
- `integration.yml` default `matrix_exclude`

This mirrors the existing pattern where `devel` already excludes Python 3.12.

**Release note**:
```release-note
NONE
```