### PR TITLE
fix(ci): remove deprecated ansible-basic-sphinx-ext from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
           cache: pip
 
       - name: Install doc dependencies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx_antsibull_ext",
-    "ansible_basic_sphinx_ext",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,4 @@ antsibull-changelog
 ansible-core
 ansible-pygments
 sphinx-rtd-theme
-git+https://github.com/felixfontein/ansible-basic-sphinx-ext
 myst-parser


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs workflow has been failing because `ansible_basic_sphinx_ext`
uses `pkg_resources`, which was removed in recent `setuptools` versions.
The `ansible-basic-sphinx-ext` package is archived and deprecated since
Dec 2022 - its functionality is already covered by `sphinx_antsibull_ext`
and `ansible-pygments`, both of which are already in the dependencies.

This PR removes `ansible_basic_sphinx_ext` from:
- `docs/conf.py` (Sphinx extensions list)
- `docs/requirements.txt` (pip dependency)

It also removes the fixed Python version pin from the docs workflow to
use the runner default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The `ansible-basic-sphinx-ext` repo has been archived since Dec 2022:
https://github.com/felixfontein/ansible-basic-sphinx-ext

**Release note**:
```release-note
NONE
```