### PR TITLE
fix(ci): set up git credential helper for checkout v7 compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,14 @@ jobs:
           cp -rp ansible_collections \
             ${{ env.work_dir }}
 
+      - name: Set up git credentials for gh-pages push
+        run: |
+          cd ${{ env.collection_dir }}
+          git config credential.helper \
+            '!f() { echo "username=x-access-token"; echo "password=${GITHUB_TOKEN}"; }; f'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create changelog and documentation
         uses: ansible-middleware/collection-docs-action@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,13 @@ jobs:
         run: |
           ansible-galaxy collection build .
 
+      - name: Set up git credentials
+        run: |
+          git config credential.helper \
+            '!f() { echo "username=x-access-token"; echo "password=${GITHUB_TOKEN}"; }; f'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create changelog and documentation
         uses: ansible-middleware/collection-docs-action@main
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

`actions/checkout` v7 (updated in #251) changed credential persistence
from `http.extraheader` to `includeIf.gitdir`-scoped config files.
`collection-docs-action` does not pick up the new credential format,
causing `git push origin gh-pages` to fail with
`fatal: could not read Username`.

This adds a git credential helper step in both `docs.yml` and
`release.yml` that provides `GITHUB_TOKEN` at auth time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The credential helper uses an environment variable (`GITHUB_TOKEN`)
rather than embedding the token in the git config. The token value is
resolved at auth time from the env var set by the workflow step.

**Release note**:
```release-note
NONE
```