### PR TITLE
fix(ci): use http.extraheader for checkout v7 credential compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,8 +53,9 @@ jobs:
       - name: Set up git credentials for gh-pages push
         run: |
           cd ${{ env.collection_dir }}
-          git config credential.helper \
-            '!f() { echo "username=x-access-token"; echo "password=${GITHUB_TOKEN}"; }; f'
+          BASIC_AUTH=$(echo -n "x-access-token:${GITHUB_TOKEN}" | base64)
+          git config --local http.https://github.com/.extraheader \
+            "AUTHORIZATION: basic ${BASIC_AUTH}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,9 @@ jobs:
 
       - name: Set up git credentials
         run: |
-          git config credential.helper \
-            '!f() { echo "username=x-access-token"; echo "password=${GITHUB_TOKEN}"; }; f'
+          BASIC_AUTH=$(echo -n "x-access-token:${GITHUB_TOKEN}" | base64)
+          git config --local http.https://github.com/.extraheader \
+            "AUTHORIZATION: basic ${BASIC_AUTH}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #254. The credential helper approach fails because the
`GITHUB_TOKEN` env var is only set during the setup step, not when
`git push` runs inside `collection-docs-action`. The helper shell
function executes in the action's process where the env var is absent.

This switches to `http.extraheader` which embeds the auth token as a
static git config value at setup time, matching the approach
`actions/checkout` v4 used. No env var is needed at push time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The token is base64-encoded into the `http.extraheader` git config
during the setup step. This is the same mechanism `actions/checkout` v4
used for credential persistence.

**Release note**:
```release-note
NONE
```