### PR TITLE
fix(ci): use global git config for http.extraheader

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,9 +52,8 @@ jobs:
 
       - name: Set up git credentials for gh-pages push
         run: |
-          cd ${{ env.collection_dir }}
           BASIC_AUTH=$(echo -n "x-access-token:${GITHUB_TOKEN}" | base64)
-          git config --local http.https://github.com/.extraheader \
+          git config --global http.https://github.com/.extraheader \
             "AUTHORIZATION: basic ${BASIC_AUTH}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up git credentials
         run: |
           BASIC_AUTH=$(echo -n "x-access-token:${GITHUB_TOKEN}" | base64)
-          git config --local http.https://github.com/.extraheader \
+          git config --global http.https://github.com/.extraheader \
             "AUTHORIZATION: basic ${BASIC_AUTH}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #255. The `--local` git config is set on the original
checkout directory, but the docs workflow copies the repo to a work
directory before the credential step runs. The `collection-docs-action`
then operates on the copy, which has its own `.git/config` without the
credentials.

Switching to `--global` makes the `http.extraheader` available to all
git operations on the runner regardless of working directory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```